### PR TITLE
fix(表格导出): 为表格和单元格添加默认宽度设置

### DIFF
--- a/packages/export-docx/src/converters/table-cell.ts
+++ b/packages/export-docx/src/converters/table-cell.ts
@@ -50,6 +50,14 @@ export function convertTableCell(
       },
     });
   }
+  if (!cell.options.width) {
+    Object.assign(cell.options, {
+      width: {
+        size: 2000, // Default width of about 1.4 inches (2000/1440)
+        type: "dxa" as const,
+      },
+    });
+  }
 
   return cell;
 }

--- a/packages/export-docx/src/converters/table-header.ts
+++ b/packages/export-docx/src/converters/table-header.ts
@@ -42,11 +42,29 @@ export function convertTableHeader(
     Object.assign(headerCell.options, { rowSpan: node.attrs.rowspan });
   }
 
-  // Add column width if present
+  // Add column width if present, otherwise use default width
   if (node.attrs?.colwidth !== null && node.attrs?.colwidth !== undefined) {
+    // colwidth is an array in TipTap, take the first value
+    const width =
+      Array.isArray(node.attrs.colwidth) && node.attrs.colwidth.length > 0
+        ? node.attrs.colwidth[0]
+        : null;
+
+    if (width) {
+      Object.assign(headerCell.options, {
+        width: {
+          size: width,
+          type: "dxa" as const,
+        },
+      });
+    }
+  }
+
+  // If no width is set, apply a default minimum width to prevent cells from being too small
+  if (!headerCell.options.width) {
     Object.assign(headerCell.options, {
       width: {
-        size: node.attrs.colwidth,
+        size: 2000, // Default width of about 1.4 inches (2000/1440)
         type: "dxa" as const,
       },
     });

--- a/packages/export-docx/src/converters/table.ts
+++ b/packages/export-docx/src/converters/table.ts
@@ -20,6 +20,14 @@ export function convertTable(
   // Build table options with options
   const tableOptions: ITableOptions = {
     rows,
+    // Set default table width if not specified
+    width: {
+      size: options?.run?.width?.size || 100,
+      type: options?.run?.width?.type || "pct",
+    },
+    // Use fixed layout to ensure cell widths are respected
+    // This is important when we set specific widths on cells
+    layout: options?.run?.layout || "fixed",
     ...options?.run, // Apply table options
   };
 


### PR DESCRIPTION
当表格或单元格未指定宽度时，设置默认宽度为1.4英寸(2000/1440 dxa)
同时为表格添加固定布局选项以确保单元格宽度被正确应用

当前表格的单元格node.attrs.colwidth 为空， 且没有文字的时候 。会导致表格宽度为 0 
<img width="590" height="412" alt="image" src="https://github.com/user-attachments/assets/26a284f2-33fc-4d7b-9d47-664b8926e02f" />
<img width="1878" height="406" alt="image" src="https://github.com/user-attachments/assets/3baec904-49e4-42c1-816e-eb3122042442" />

