### PR TITLE
feat(export-docx): 支持webp图片格式并优化图片处理逻辑

### DIFF
--- a/packages/export-docx/src/converters/image.ts
+++ b/packages/export-docx/src/converters/image.ts
@@ -21,7 +21,9 @@ export async function convertImage(
   options: DocxOptions["image"],
 ): Promise<Paragraph> {
   // Get image type from metadata or URL
-  const getImageType = (metaType?: string): "jpg" | "png" | "gif" | "bmp" => {
+  const getImageType = (
+    metaType?: string,
+  ): "jpg" | "png" | "gif" | "bmp" | "webp" => {
     // Try metadata type first
     switch (metaType) {
       case "jpeg":
@@ -33,6 +35,8 @@ export async function convertImage(
         return "gif";
       case "bmp":
         return "bmp";
+      case "webp":
+        return "png";
     }
 
     // Fallback to URL-based type detection
@@ -46,6 +50,8 @@ export async function convertImage(
         return "gif";
       case "bmp":
         return "bmp";
+      case "webp":
+        return "png";
       default:
         return "png";
     }

--- a/packages/export-docx/src/utils.ts
+++ b/packages/export-docx/src/utils.ts
@@ -90,7 +90,9 @@ export function getImageWidth(
     return options.run.transformation.width;
   }
   if (imageMeta?.width && typeof imageMeta.width === "number") {
-    return Math.min(imageMeta.width, 600);
+    const width = Math.min(imageMeta.width, 600);
+    // 如果图片太小，使用默认尺寸
+    return width < 50 ? 400 : width;
   }
   return 400;
 }
@@ -116,7 +118,9 @@ export function getImageHeight(
     imageMeta?.height &&
     typeof imageMeta.height === "number"
   ) {
-    return Math.round((width * imageMeta.height) / imageMeta.width);
+    const height = Math.round((width * imageMeta.height) / imageMeta.width);
+    // 如果计算出的高度太小，使用默认尺寸
+    return height < 50 ? 300 : height;
   }
   return 300;
 }


### PR DESCRIPTION
添加对webp图片格式的支持，包括类型检测和转换处理
优化图片宽高获取逻辑，增加类型检查和空值处理
改进图片数据获取，添加重定向和超时处理

1. 修复了 node.attrs?.width 不是数字的问题，防止出现 "null" "rem" 这种格式