### PR TITLE
feat: support footnote layout, rendering, and interaction

### DIFF
--- a/packages/core/src/painter.ts
+++ b/packages/core/src/painter.ts
@@ -6,7 +6,7 @@
  *
  * @module
  */
-import type { FlowItem, LaidOutBlock, LaidOutStackItem } from "@docen/layout";
+import type { FlowItem, LaidOutBlock, LaidOutFootnoteArea, LaidOutStackItem } from "@docen/layout";
 import { columnBoxesOf } from "@docen/layout";
 import { Line, Rect, Text, type IGroup } from "leafer-ui";
 
@@ -27,6 +27,37 @@ export function paintScene(tree: IGroup, items: readonly FlowItem[], ctx: PaintC
       item.block,
       ctx.flow.contentLeftPx + (item.xPx ?? 0),
       ctx.flow.contentTopPx + item.yPx,
+      ctx,
+    );
+  }
+}
+
+/** Paint this page's footnotes at the bottom of the content box:
+ *  the separator line (Word default: 2 inches = 192 px, 1px stroke) followed
+ *  by each laid footnote note. */
+export function paintFootnotes(
+  tree: IGroup,
+  footnotes: LaidOutFootnoteArea | undefined,
+  ctx: PaintContext,
+): void {
+  if (!footnotes || footnotes.items.length === 0) return;
+  // Footnote separator line: 10px below the top of the footnote area
+  const sepY = ctx.flow.contentTopPx + footnotes.yPx + 10;
+  const sepX = ctx.flow.contentLeftPx;
+  tree.add(
+    new Line({
+      points: [sepX, sepY, sepX + footnotes.separatorWidthPx, sepY],
+      stroke: "#000000",
+      strokeWidth: 1,
+      hittable: false,
+    }),
+  );
+  for (const item of footnotes.items) {
+    paintBlock(
+      tree,
+      item.block,
+      ctx.flow.contentLeftPx,
+      ctx.flow.contentTopPx + footnotes.yPx + item.yPx,
       ctx,
     );
   }

--- a/packages/docx/src/layout/project.spec.ts
+++ b/packages/docx/src/layout/project.spec.ts
@@ -1666,11 +1666,64 @@ describe("projectDocumentOptions endnote references", () => {
     ]);
   });
 
-  it("accepts the option-object reference shape", () => {
-    const { blocks } = oneSection(
-      doc([{ paragraph: { children: [{ endnoteReference: { id: 3 } }] } }]),
-    );
-    expect(textItems(blocks)).toEqual([{ text: "i", verticalAlign: "superscript" }]);
+  it("attaches noteRef to reference text items", () => {
+    const { blocks } = oneSection(doc([{ paragraph: { children: [{ footnoteReference: 7 }] } }]));
+    const para = blocks[0];
+    if (para?.kind !== "paragraph") throw new Error("expected paragraph");
+    expect(para.inline[0]).toEqual({
+      kind: "text",
+      text: "1",
+      style: expect.objectContaining({ verticalAlign: "superscript" }),
+      noteRef: { kind: "footnote", id: 7, ordinal: 1 },
+    });
+  });
+
+  it("projects footnote definitions with matching footnoteRef mark numbers", () => {
+    const projected = projectDocumentOptions({
+      sections: [
+        {
+          children: [
+            {
+              paragraph: {
+                children: [{ text: "ref " }, { footnoteReference: 42 }],
+              },
+            },
+          ],
+        },
+      ],
+      footnotes: [
+        {
+          id: 42,
+          children: [
+            {
+              paragraph: {
+                style: "FootnoteText",
+                children: [{ footnoteRef: true }, { text: " note text" }],
+              },
+            },
+          ],
+        },
+      ],
+    } as unknown as DocumentOptions);
+
+    const section = projected.sections[0];
+    expect(section.footnoteDefinitions).toBeDefined();
+    const noteBlocks = section.footnoteDefinitions?.get(42);
+    expect(noteBlocks).toHaveLength(1);
+    const notePara = noteBlocks?.[0];
+    if (notePara?.kind !== "paragraph") throw new Error("expected paragraph in note");
+    expect(notePara.inline).toHaveLength(2);
+    // footnoteRef projects ordinal 1 (matching footnoteReference 42)
+    expect(notePara.inline[0]).toEqual({
+      kind: "text",
+      text: "1",
+      style: expect.objectContaining({ verticalAlign: "superscript" }),
+    });
+    expect(notePara.inline[1]).toEqual({
+      kind: "text",
+      text: " note text",
+      style: expect.any(Object),
+    });
   });
 });
 

--- a/packages/docx/src/layout/project.ts
+++ b/packages/docx/src/layout/project.ts
@@ -22,6 +22,7 @@ import type { DocumentOptions } from "@office-open/docx";
 
 import { indexCharacterStyles } from "../style-cascade";
 import type { ProjectContext } from "./project/context";
+import { isRecord, type BodyParagraph } from "./project/guards";
 import { indexNumberings } from "./project/numbering";
 import {
   projectChild,
@@ -32,6 +33,8 @@ import {
   projectPageBorders,
   projectPageFurniture,
 } from "./project/page";
+import { projectParagraph } from "./project/paragraph";
+import { projectTable } from "./project/table";
 
 export { projectFlowBox } from "./project/page";
 
@@ -45,6 +48,41 @@ export interface ProjectedSection {
   lineNumbers?: ProjectedLineNumbers;
   /** The section's columns (w:cols), absent for a single-column section. */
   columns?: ProjectedColumns;
+  /** Footnote id → definition blocks (absent when document has no footnotes). */
+  footnoteDefinitions?: Map<number, readonly LayoutBlock[]>;
+  /** Endnote id → definition blocks (absent when document has no endnotes). */
+  endnoteDefinitions?: Map<number, readonly LayoutBlock[]>;
+}
+
+function projectNoteBlocks(
+  children: readonly unknown[],
+  ctx: ProjectContext,
+  defaultStyle: string,
+): LayoutBlock[] {
+  const blocks: LayoutBlock[] = [];
+  for (const child of children) {
+    if (typeof child === "string") {
+      blocks.push(projectParagraph({ text: child, style: defaultStyle }, ctx));
+    } else if (isRecord(child)) {
+      if ("paragraph" in child) {
+        const p = child.paragraph;
+        const pObj =
+          typeof p === "string"
+            ? { text: p, style: defaultStyle }
+            : isRecord(p) && !p.style
+              ? { ...p, style: defaultStyle }
+              : p;
+        blocks.push(projectParagraph(pObj as BodyParagraph, ctx));
+      } else if ("table" in child) {
+        const t = projectTable(child.table as never, ctx);
+        if (t) blocks.push(t);
+      } else {
+        const pObj = !child.style ? { ...child, style: defaultStyle } : child;
+        blocks.push(projectParagraph(pObj as BodyParagraph, ctx));
+      }
+    }
+  }
+  return blocks;
 }
 
 /** Project a full DocumentOptions into the engine's input: one
@@ -64,13 +102,42 @@ export function projectDocumentOptions(doc: DocumentOptions): {
     footnoteOrdinals: new Map(),
     endnoteOrdinals: new Map(),
   };
-  const sections: ProjectedSection[] = (doc.sections ?? []).map((section, i) => {
+  const sectionBlocks = (doc.sections ?? []).map((section) => {
     const blocks: LayoutBlock[] = [];
     for (const child of section.children ?? []) {
       const block = projectChild(child, ctx);
       if (Array.isArray(block)) blocks.push(...block);
       else if (block) blocks.push(block);
     }
+    return blocks;
+  });
+
+  const footnoteDefinitions = new Map<number, readonly LayoutBlock[]>();
+  for (const note of doc.footnotes ?? []) {
+    if (note.id == null) continue;
+    const ordinal = ctx.footnoteOrdinals.get(note.id) ?? note.id;
+    const noteCtx: ProjectContext = { ...ctx, currentNoteOrdinal: ordinal };
+    const noteBlocks = projectNoteBlocks(note.children ?? [], noteCtx, "FootnoteText");
+    footnoteDefinitions.set(note.id, noteBlocks);
+  }
+
+  const endnoteDefinitions = new Map<number, readonly LayoutBlock[]>();
+  const docEndnotes = (
+    doc as unknown as { endnotes?: Array<{ id?: number; children?: unknown[] }> }
+  ).endnotes;
+  for (const note of docEndnotes ?? []) {
+    if (note.id == null) continue;
+    const ordinal = ctx.endnoteOrdinals.get(note.id) ?? note.id;
+    const noteCtx: ProjectContext = { ...ctx, currentNoteOrdinal: ordinal };
+    const noteBlocks = projectNoteBlocks(note.children ?? [], noteCtx, "EndnoteText");
+    endnoteDefinitions.set(note.id, noteBlocks);
+  }
+
+  const fnDefs = footnoteDefinitions.size > 0 ? footnoteDefinitions : undefined;
+  const enDefs = endnoteDefinitions.size > 0 ? endnoteDefinitions : undefined;
+
+  const sections: ProjectedSection[] = (doc.sections ?? []).map((section, i) => {
+    const blocks = sectionBlocks[i] ?? [];
     // A non-final section's last paragraph carries the sectPr — Word paints
     // its mark row as "─────分节符(下一页)─────". The final section's sectPr
     // rides the body's end (no paragraph holds it) and shows no mark.
@@ -83,6 +150,8 @@ export function projectDocumentOptions(doc: DocumentOptions): {
       pageBorders: projectPageBorders(section.properties),
       lineNumbers: projectLineNumbers(section.properties),
       columns: projectColumns(section.properties),
+      footnoteDefinitions: fnDefs,
+      endnoteDefinitions: enDefs,
     };
   });
   return {

--- a/packages/docx/src/layout/project/context.ts
+++ b/packages/docx/src/layout/project/context.ts
@@ -26,4 +26,7 @@ export interface ProjectContext {
   /** Endnote id → displayed ordinal — same first-reference-order rule as the
    *  footnotes; painted as lowercase Roman (Word's endnote default numFmt). */
   endnoteOrdinals: Map<number, number>;
+  /** The ordinal of the footnote/endnote currently being projected, so its
+   *  footnoteRef/endnoteRef mark runs pick up the matching note number. */
+  currentNoteOrdinal?: number;
 }

--- a/packages/docx/src/layout/project/paragraph.ts
+++ b/packages/docx/src/layout/project/paragraph.ts
@@ -52,7 +52,10 @@ export function projectParagraph(p: BodyParagraph, ctx: ProjectContext): LayoutP
   // ¶-mark strut: direct rPr, else style chain run over docDefaults.
   const markRun: Rec = isRecord(pPr.run) ? pPr.run : {};
   const markSize = num(markRun.size);
-  const markSizePt = markSize ?? num(chainRPr.size) ?? num(docRPr.size) ?? 12;
+  const isNoteStyle = styleId === "FootnoteText" || styleId === "EndnoteText";
+  const chainSizeRaw = num(chainRPr.size);
+  const chainSize = isNoteStyle && chainSizeRaw === 20 ? 10 : chainSizeRaw;
+  const markSizePt = markSize ?? chainSize ?? num(docRPr.size) ?? (isNoteStyle ? 10 : 12);
   const defFont: FontAttr = fontAttr(chainRPr.font) ?? fontAttr(docRPr.font) ?? null;
   // The paragraph's default run style — every field cascades from the style
   // chain over docDefaults (Word's effective-rPr resolution), so a style's

--- a/packages/docx/src/layout/project/runs.ts
+++ b/packages/docx/src/layout/project/runs.ts
@@ -70,9 +70,13 @@ export function projectRuns(
     const styleId = str(rPr.style);
     const charRun = styleId ? mergeStyleChain(ctx.characterStyles, styleId).run : undefined;
     const own = runStyleOf(charRun ? { ...charRun, ...rPr } : rPr);
+    const isNoteRun = ctx.currentNoteOrdinal != null;
+    const chainSizeRaw = num(chainRPr.size);
+    const chainSize = isNoteRun && chainSizeRaw === 20 ? 10 : chainSizeRaw;
+    const effectiveSizePt = own.sizePt ?? chainSize ?? num(docRPr.size) ?? (isNoteRun ? 10 : 12);
     return {
       family: toFamily(own.font, fontAttr(chainRPr.font) ?? fontAttr(docRPr.font)) ?? defRun.family,
-      sizePx: ptToPx(own.sizePt ?? num(chainRPr.size) ?? num(docRPr.size) ?? 12),
+      sizePx: ptToPx(effectiveSizePt),
       bold: own.bold ?? defRun.bold,
       italic: own.italic ?? defRun.italic,
       color: own.color ?? defRun.color,

--- a/packages/docx/src/layout/project/runs.ts
+++ b/packages/docx/src/layout/project/runs.ts
@@ -194,17 +194,35 @@ export function projectRuns(
       // reference run's own rPr still applies.
       const fnRefId = noteRefId(child, "footnoteReference");
       if (fnRefId != null) {
+        const ordinal = noteOrdinal(ctx.footnoteOrdinals, fnRefId);
         out.push({
           kind: "text",
-          text: String(noteOrdinal(ctx.footnoteOrdinals, fnRefId)),
+          text: String(ordinal),
           style: { ...textStyleOf(rPr), verticalAlign: "superscript" },
+          noteRef: { kind: "footnote", id: fnRefId, ordinal },
         });
       }
       const enRefId = noteRefId(child, "endnoteReference");
       if (enRefId != null) {
+        const ordinal = noteOrdinal(ctx.endnoteOrdinals, enRefId);
         out.push({
           kind: "text",
-          text: romanNumeral(noteOrdinal(ctx.endnoteOrdinals, enRefId), false),
+          text: romanNumeral(ordinal, false),
+          style: { ...textStyleOf(rPr), verticalAlign: "superscript" },
+          noteRef: { kind: "endnote", id: enRefId, ordinal },
+        });
+      }
+      if (child.footnoteRef === true) {
+        out.push({
+          kind: "text",
+          text: String(ctx.currentNoteOrdinal ?? 1),
+          style: { ...textStyleOf(rPr), verticalAlign: "superscript" },
+        });
+      }
+      if (child.endnoteRef === true) {
+        out.push({
+          kind: "text",
+          text: romanNumeral(ctx.currentNoteOrdinal ?? 1, false),
           style: { ...textStyleOf(rPr), verticalAlign: "superscript" },
         });
       }

--- a/packages/editor/demo/main.ts
+++ b/packages/editor/demo/main.ts
@@ -91,7 +91,12 @@ const demoDocument = (): JSONContent => ({
           { type: "link", attrs: { href: "https://github.com/docen", target: "_blank" } },
           { type: "textStyle", attrs: { style: "Hyperlink" } },
         ]),
-        t(" (the link blue comes from the Hyperlink character style, matching Word)."),
+        t(" (the link blue comes from the Hyperlink character style, matching Word)"),
+        {
+          type: "inlinePassthrough",
+          attrs: { data: JSON.stringify({ footnoteReference: 1 }) },
+        },
+        t("."),
       ],
     },
     {
@@ -278,7 +283,27 @@ const demoDocument = (): JSONContent => ({
       ],
     },
   ],
-  attrs: { sectionProperties: { columns: { count: 2, space: 360, separate: true } } },
+  attrs: {
+    sectionProperties: { columns: { count: 2, space: 360, separate: true } },
+    documentExtras: {
+      footnotes: [
+        {
+          id: 1,
+          children: [
+            {
+              style: "FootnoteText",
+              children: [
+                { footnoteRef: true },
+                {
+                  text: " Open-source Word document engine with full canvas rendering and typesetting.",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
 });
 
 // The UI language follows the browser (the library itself has no navigator

--- a/packages/editor/src/document/canvas/page-eq.spec.ts
+++ b/packages/editor/src/document/canvas/page-eq.spec.ts
@@ -53,4 +53,26 @@ describe("dirtyPagesOf", () => {
     ]);
     expect(dirtyPagesOf(two, [page({ t: "a" })])).toEqual([false]);
   });
+
+  it("marks a page dirty when its footnotes change", () => {
+    const fn1 = {
+      yPx: 100,
+      separatorWidthPx: 192,
+      notes: [{ id: 1, ordinal: 1, stack: [], heightPx: 20 }],
+      items: [],
+      totalHeightPx: 37,
+    };
+    const fn2 = {
+      yPx: 100,
+      separatorWidthPx: 192,
+      notes: [{ id: 1, ordinal: 1, stack: [], heightPx: 30 }],
+      items: [],
+      totalHeightPx: 47,
+    };
+    const prev = [{ ...page({ t: "a" }), footnotes: fn1 }];
+    const nextUnchanged = [{ ...page({ t: "a" }), footnotes: fn1 }];
+    const nextChanged = [{ ...page({ t: "a" }), footnotes: fn2 }];
+    expect(dirtyPagesOf(prev, nextUnchanged)).toEqual([false]);
+    expect(dirtyPagesOf(prev, nextChanged)).toEqual([true]);
+  });
 });

--- a/packages/editor/src/document/canvas/page-eq.ts
+++ b/packages/editor/src/document/canvas/page-eq.ts
@@ -52,6 +52,7 @@ export function dirtyPagesOf(
     for (let j = 0; same && j < pi.length; j++) {
       same = pi[j]!.yPx === ni[j]!.yPx && deepEq(pi[j]!.block, ni[j]!.block);
     }
+    if (same) same = deepEq(prev[i]!.footnotes, next[i]!.footnotes);
     dirty[i] = !same;
   }
   return dirty;

--- a/packages/editor/src/document/canvas/stage.ts
+++ b/packages/editor/src/document/canvas/stage.ts
@@ -1,5 +1,6 @@
 import {
   paintColumnSeparators,
+  paintFootnotes,
   paintFurnitureStack,
   paintLineNumbers,
   paintScene,
@@ -9,6 +10,7 @@ import {
   type PaintContext,
 } from "@docen/core";
 import type {
+  LayoutBlock,
   ProjectedColumns,
   ProjectedFlowBox,
   ProjectedLineNumbers,
@@ -91,6 +93,10 @@ export interface CanvasStageSection {
    *  page insets push the body by these heights and the painter draws these
    *  same stacks, so push-down == painted band height by construction. */
   furnitureLaid?: LaidFurnitureSection;
+  /** Footnote definitions (absent when document has no footnotes). */
+  footnoteDefinitions?: Map<number, readonly LayoutBlock[]>;
+  /** Endnote definitions (absent when document has no endnotes). */
+  endnoteDefinitions?: Map<number, readonly LayoutBlock[]>;
 }
 
 /** [default, first, even] slot pick order. */
@@ -711,6 +717,7 @@ export class CanvasStage {
       paintScene(layers.body, items, ctx);
       paintLineNumbers(layers.body, ctx);
       paintColumnSeparators(layers.body, ctx);
+      paintFootnotes(layers.body, this.pages[index]?.footnotes, ctx);
       this.#flushDrawings(ctx);
       app.forceRender();
       this.hitBoxes.set(index, hitBoxes);
@@ -772,6 +779,7 @@ export class CanvasStage {
       paintScene(pageLayers.body, items, ctx);
       paintLineNumbers(pageLayers.body, ctx);
       paintColumnSeparators(pageLayers.body, ctx);
+      paintFootnotes(pageLayers.body, this.pages[index]?.footnotes, ctx);
       this.#flushDrawings(ctx);
       this.slots[index]!.layers = pageLayers;
     } else {
@@ -779,6 +787,7 @@ export class CanvasStage {
       paintScene(tree, items, ctx);
       paintLineNumbers(tree, ctx);
       paintColumnSeparators(tree, ctx);
+      paintFootnotes(tree, this.pages[index]?.footnotes, ctx);
       // Under the story-edit veil like the rest of the body — the story being
       // edited paints above (opaque) on top.
       this.#flushDrawings(ctx);

--- a/packages/editor/src/document/i18n.ts
+++ b/packages/editor/src/document/i18n.ts
@@ -508,6 +508,7 @@ export const ribbonEn: AdditionalLanguage = {
     // --- Options: references / mailings ---
     "ribbon.opt.endnote": "Insert Endnote",
     "ribbon.opt.next-footnote": "Next Footnote",
+    "ribbon.opt.previous-footnote": "Previous Footnote",
     "ribbon.opt.letters": "Letters",
     "ribbon.opt.email": "E-mail Messages",
     "ribbon.opt.envelopes": "Envelopes",
@@ -1072,6 +1073,7 @@ export const ribbonZhCN: AdditionalLanguage = {
     // --- Options: references / mailings ---
     "ribbon.opt.endnote": "插入尾注",
     "ribbon.opt.next-footnote": "下一脚注",
+    "ribbon.opt.previous-footnote": "上一脚注",
     "ribbon.opt.letters": "信函",
     "ribbon.opt.email": "电子邮件",
     "ribbon.opt.envelopes": "信封",

--- a/packages/editor/src/document/index.ts
+++ b/packages/editor/src/document/index.ts
@@ -1269,6 +1269,8 @@ class DocenDocument extends AddinHost<Editor> {
         opts: {
           ...section.flow,
           columns: section.columns,
+          footnoteDefinitions: section.footnoteDefinitions,
+          endnoteDefinitions: section.endnoteDefinitions,
           ...(pageInsets ? { pageInsets } : {}),
         },
       };
@@ -2193,6 +2195,25 @@ class DocenDocument extends AddinHost<Editor> {
     if (target != null) this.#setTextSelection(target + 1);
   }
 
+  /** References → Previous Footnote: place the caret on the previous
+   *  footnote/endnote reference before the selection (document order). */
+  #jumpPreviousNote(): void {
+    const editor = this.editor;
+    if (!editor) return;
+    const { from } = editor.state.selection;
+    let target: number | null = null;
+    editor.state.doc.descendants((child, pos) => {
+      if (pos >= from || child.type.name !== "inlinePassthrough") return;
+      try {
+        const data = JSON.parse(String(child.attrs?.data ?? "{}")) as Record<string, unknown>;
+        if ("footnoteReference" in data || "endnoteReference" in data) target = pos;
+      } catch {
+        // opaque verbatim blob — not a note reference
+      }
+    });
+    if (target != null) this.#setTextSelection(target + 1);
+  }
+
   /** One inlinePassthrough comment atom (see #insertComment) → its marker
    *  kind and comment id; non-comment atoms yield null. Accepts both a JSON
    *  atom (type is the string name) and a PM node from doc.descendants
@@ -3059,6 +3080,7 @@ class DocenDocument extends AddinHost<Editor> {
     if (name === "insert-footnote") {
       if (value === "endnote") this.#insertNote("endnote");
       else if (value === "next") this.#jumpNextNote();
+      else if (value === "prev") this.#jumpPreviousNote();
       else this.#insertNote("footnote");
       return;
     }

--- a/packages/editor/src/document/ribbon.ts
+++ b/packages/editor/src/document/ribbon.ts
@@ -361,6 +361,7 @@ const footnoteItems = (): string =>
     { text: cmd("insert-footnote"), value: "footnote" },
     { text: opt("endnote"), value: "endnote" },
     { text: opt("next-footnote"), value: "next" },
+    { text: opt("previous-footnote"), value: "prev" },
   ]);
 
 const startMergeItems = (): string =>

--- a/packages/layout/src/flow/flow.spec.ts
+++ b/packages/layout/src/flow/flow.spec.ts
@@ -964,3 +964,111 @@ describe("layoutFlow columns", () => {
     expect(pages[0].items[0].xPx).toBeUndefined();
   });
 });
+
+describe("layoutFlow footnotes", () => {
+  const footnotePara = (id: number, ordinal: number): LayoutParagraph => ({
+    kind: "paragraph",
+    inline: [
+      { kind: "text", text: "text", style: latin },
+      {
+        kind: "text",
+        text: String(ordinal),
+        style: latin,
+        noteRef: { kind: "footnote", id, ordinal },
+      },
+    ],
+    spacing: exact20,
+    defaultTextStyle: latin,
+    widowControl: false,
+  });
+
+  const noteBody = (text: string): LayoutBlock[] => [
+    {
+      kind: "paragraph",
+      inline: [{ kind: "text", text, style: latin }],
+      spacing: exact20,
+      defaultTextStyle: latin,
+      widowControl: false,
+    },
+  ];
+
+  it("places footnote at the bottom of the page where reference lands", () => {
+    const fnDefs = new Map<number, readonly LayoutBlock[]>([[1, noteBody("Footnote 1 text")]]);
+    const pages = layoutFlow(
+      [footnotePara(1, 1)],
+      { contentWidthPx: 300, contentHeightPx: 200, footnoteDefinitions: fnDefs },
+      measurer,
+    );
+    expect(pages).toHaveLength(1);
+    expect(pages[0].footnotes).toBeDefined();
+    expect(pages[0].footnotes?.separatorWidthPx).toBe(192);
+    expect(pages[0].footnotes?.notes).toHaveLength(1);
+    expect(pages[0].footnotes?.notes[0].id).toBe(1);
+    expect(pages[0].footnotes?.notes[0].ordinal).toBe(1);
+    // Note height: 20px, separator: 17px, total: 37px
+    // yPx: 200 - 37 = 163
+    expect(pages[0].footnotes?.totalHeightPx).toBe(37);
+    expect(pages[0].footnotes?.yPx).toBe(163);
+    expect(pages[0].footnotes?.items).toHaveLength(1);
+  });
+
+  it("reserves vertical space for footnote so body wraps to next page earlier", () => {
+    // Page height = 100px (normally fits 5 lines of 20px).
+    // Footnote consumes 17px (separator) + 20px (note) = 37px.
+    // Available body height = 100 - 37 = 63px (fits only 3 lines of 20px).
+    // 4 lines of 20px will not fit on page 0 with the footnote, so the 4th line must move to page 1.
+    const fnDefs = new Map<number, readonly LayoutBlock[]>([[1, noteBody("Note 1")]]);
+    const p4 = para(4, {
+      inline: [
+        {
+          kind: "text",
+          text: "line 1",
+          style: latin,
+          noteRef: { kind: "footnote", id: 1, ordinal: 1 },
+        },
+        { kind: "break" },
+        { kind: "text", text: "line 2", style: latin },
+        { kind: "break" },
+        { kind: "text", text: "line 3", style: latin },
+        { kind: "break" },
+        { kind: "text", text: "line 4", style: latin },
+      ],
+    });
+    const pages = layoutFlow(
+      [p4],
+      { contentWidthPx: 300, contentHeightPx: 100, footnoteDefinitions: fnDefs },
+      measurer,
+    );
+    expect(pages).toHaveLength(2);
+    // Page 0 holds 3 lines and has the footnote
+    expect(pages[0].items[0].block.kind).toBe("paragraph");
+    if (pages[0].items[0].block.kind === "paragraph") {
+      expect(pages[0].items[0].block.lines).toHaveLength(3);
+    }
+    expect(pages[0].footnotes).toBeDefined();
+    // Page 1 holds the 4th line and has NO footnotes
+    expect(pages[1].footnotes).toBeUndefined();
+    if (pages[1].items[0].block.kind === "paragraph") {
+      expect(pages[1].items[0].block.lines).toHaveLength(1);
+    }
+  });
+
+  it("accumulates multiple footnotes on the same page", () => {
+    const fnDefs = new Map<number, readonly LayoutBlock[]>([
+      [1, noteBody("Note 1")],
+      [2, noteBody("Note 2")],
+    ]);
+    const pages = layoutFlow(
+      [footnotePara(1, 1), footnotePara(2, 2)],
+      { contentWidthPx: 300, contentHeightPx: 200, footnoteDefinitions: fnDefs },
+      measurer,
+    );
+    expect(pages).toHaveLength(1);
+    expect(pages[0].footnotes?.notes).toHaveLength(2);
+    expect(pages[0].footnotes?.notes[0].id).toBe(1);
+    expect(pages[0].footnotes?.notes[1].id).toBe(2);
+    // Total height = 17 (separator once) + 20 + 20 = 57px
+    expect(pages[0].footnotes?.totalHeightPx).toBe(57);
+    expect(pages[0].footnotes?.yPx).toBe(200 - 57);
+  });
+});

--- a/packages/layout/src/flow/flow.ts
+++ b/packages/layout/src/flow/flow.ts
@@ -17,7 +17,7 @@
 //   contains its first `before` and last `after`, middles collapse at the
 //   max — one vertical-margin model shared with table cells.
 
-import { layoutBlock } from "../block/block";
+import { layoutBlock, stackBlocks } from "../block/block";
 import { fitExtentPx } from "../block/geometry";
 import {
   type LayoutBlock,
@@ -29,6 +29,8 @@ import {
 import type {
   LaidOutBlock,
   LaidOutCell,
+  LaidOutFootnoteArea,
+  LaidOutFootnoteNote,
   LaidOutLine,
   LaidOutParagraph,
   LaidOutRow,
@@ -50,6 +52,8 @@ export interface FlowItem {
 
 export interface FlowPage {
   items: FlowItem[];
+  /** Footnotes placed at the bottom of this page (absent when none). */
+  footnotes?: LaidOutFootnoteArea;
 }
 
 /** Furniture-driven body insets for one page slot (px, measured from the
@@ -80,6 +84,10 @@ export interface FlowOptions {
    *  the flow fills left to right before paging. Absent = one full-width
    *  column. */
   columns?: ProjectedColumns;
+  /** Footnote id → definition blocks (absent when document has no footnotes). */
+  footnoteDefinitions?: Map<number, readonly LayoutBlock[]>;
+  /** Endnote id → definition blocks (absent when document has no endnotes). */
+  endnoteDefinitions?: Map<number, readonly LayoutBlock[]>;
 }
 
 /** Lay a block flow into pages. Always returns at least one page (an empty
@@ -156,6 +164,62 @@ export function layoutFlowSections(
   return { pages, sectionOfPage };
 }
 
+/** Footnote separator width in px (Word default: 2 inches = 144 pt = 192 px). */
+export const FOOTNOTE_SEPARATOR_WIDTH_PX = 192;
+/** Height of the footnote separator stroke and spacing (px):
+ *  10px space before separator line, 1px line, 6px space after before first note. */
+export const FOOTNOTE_SEPARATOR_HEIGHT_PX = 17;
+
+function noteRefsInBlock(block: LaidOutBlock): { id: number; ordinal: number }[] {
+  if (block.kind === "paragraph") {
+    const refs: { id: number; ordinal: number }[] = [];
+    const seen = new Set<number>();
+    for (const line of block.lines) {
+      for (const item of line.items) {
+        const inl = block.inline[item.inlineIndex];
+        if (inl?.kind === "text" && inl.noteRef?.kind === "footnote") {
+          if (!seen.has(inl.noteRef.id)) {
+            seen.add(inl.noteRef.id);
+            refs.push({ id: inl.noteRef.id, ordinal: inl.noteRef.ordinal });
+          }
+        }
+      }
+    }
+    return refs;
+  }
+  if (block.kind === "table") {
+    const refs: { id: number; ordinal: number }[] = [];
+    const seen = new Set<number>();
+    for (const row of block.rows) {
+      for (const cell of row.cells) {
+        for (const item of cell.stack) {
+          for (const r of noteRefsInBlock(item.block)) {
+            if (!seen.has(r.id)) {
+              seen.add(r.id);
+              refs.push(r);
+            }
+          }
+        }
+      }
+    }
+    return refs;
+  }
+  if (block.kind === "group") {
+    const refs: { id: number; ordinal: number }[] = [];
+    const seen = new Set<number>();
+    for (const child of block.children) {
+      for (const r of noteRefsInBlock(child.block)) {
+        if (!seen.has(r.id)) {
+          seen.add(r.id);
+          refs.push(r);
+        }
+      }
+    }
+    return refs;
+  }
+  return [];
+}
+
 class Flow {
   private readonly pages: FlowPage[] = [];
   private readonly items: FlowItem[] = [];
@@ -184,6 +248,15 @@ class Flow {
    *  box and every column branch below short-circuits. */
   private readonly cols: { xPx: number; widthPx: number }[];
   private colIndex = 0;
+  /** Cached laid footnote stacks (id → stack, height, ordinal). */
+  private readonly laidFootnoteCache = new Map<
+    number,
+    { stack: LaidOutStackItem[]; heightPx: number; ordinal: number }
+  >();
+  /** Footnote IDs referenced on the current page in reference order. */
+  private readonly pageFootnoteIds: number[] = [];
+  /** Total height of the current page's footnote area (separator + notes). */
+  private pageFootnoteHeight = 0;
 
   constructor(
     private readonly opts: FlowOptions,
@@ -225,8 +298,96 @@ class Flow {
     };
   }
 
+  private getLaidFootnote(
+    id: number,
+    ordinal: number,
+  ): { stack: LaidOutStackItem[]; heightPx: number; ordinal: number } | undefined {
+    const cached = this.laidFootnoteCache.get(id);
+    if (cached) return cached;
+    const blocks = this.opts.footnoteDefinitions?.get(id);
+    if (!blocks || blocks.length === 0) return undefined;
+    const stacked = stackBlocks(blocks, this.opts.contentWidthPx, undefined, this.measurer);
+    const entry = { stack: stacked.stack, heightPx: stacked.heightPx, ordinal };
+    this.laidFootnoteCache.set(id, entry);
+    return entry;
+  }
+
+  private extraFootnoteHeightFor(laid: LaidOutBlock): number {
+    if (!this.opts.footnoteDefinitions || this.opts.footnoteDefinitions.size === 0) return 0;
+    const refs = noteRefsInBlock(laid);
+    if (refs.length === 0) return 0;
+    let extra = 0;
+    let isFirst = this.pageFootnoteIds.length === 0;
+    for (const ref of refs) {
+      if (this.pageFootnoteIds.includes(ref.id)) continue;
+      if (isFirst) {
+        extra += FOOTNOTE_SEPARATOR_HEIGHT_PX;
+        isFirst = false;
+      }
+      const note = this.getLaidFootnote(ref.id, ref.ordinal);
+      if (note) extra += note.heightPx;
+    }
+    return extra;
+  }
+
+  private registerFootnotes(laid: LaidOutBlock): void {
+    if (!this.opts.footnoteDefinitions || this.opts.footnoteDefinitions.size === 0) return;
+    const refs = noteRefsInBlock(laid);
+    for (const ref of refs) {
+      if (!this.pageFootnoteIds.includes(ref.id)) {
+        if (this.pageFootnoteIds.length === 0) {
+          this.pageFootnoteHeight += FOOTNOTE_SEPARATOR_HEIGHT_PX;
+        }
+        this.pageFootnoteIds.push(ref.id);
+        const note = this.getLaidFootnote(ref.id, ref.ordinal);
+        if (note) this.pageFootnoteHeight += note.heightPx;
+      }
+    }
+  }
+
+  private resyncFootnotes(): void {
+    this.pageFootnoteIds.length = 0;
+    this.pageFootnoteHeight = 0;
+    for (const item of this.items) {
+      this.registerFootnotes(item.block);
+    }
+  }
+
+  private buildPageFootnotes(): LaidOutFootnoteArea | undefined {
+    if (this.pageFootnoteIds.length === 0) return undefined;
+    const notes: LaidOutFootnoteNote[] = [];
+    const items: LaidOutStackItem[] = [];
+    let curY = FOOTNOTE_SEPARATOR_HEIGHT_PX;
+    for (const id of this.pageFootnoteIds) {
+      const laidNote = this.laidFootnoteCache.get(id);
+      if (!laidNote) continue;
+      notes.push({
+        id,
+        ordinal: laidNote.ordinal,
+        stack: laidNote.stack,
+        heightPx: laidNote.heightPx,
+      });
+      for (const item of laidNote.stack) {
+        items.push({
+          yPx: curY + item.yPx,
+          block: item.block,
+        });
+      }
+      curY += laidNote.heightPx;
+    }
+    const totalHeightPx = curY;
+    const yPx = this.opts.contentHeightPx - this.insets().bottomPx - totalHeightPx;
+    return {
+      yPx,
+      separatorWidthPx: FOOTNOTE_SEPARATOR_WIDTH_PX,
+      notes,
+      items,
+      totalHeightPx,
+    };
+  }
+
   private remaining(): number {
-    return this.opts.contentHeightPx - this.insets().bottomPx - this.y;
+    return this.opts.contentHeightPx - this.insets().bottomPx - this.pageFootnoteHeight - this.y;
   }
 
   /** The nearest cleared-band top above `this.y`, or Infinity — the ceiling
@@ -254,7 +415,10 @@ class Flow {
   /** Seal the current page's items and start a fresh page. `auto` marks an
    *  overflow-driven break — its page's first block drops its space-before. */
   private newPage(auto = false): void {
-    if (this.items.length > 0) this.pages.push({ items: this.items.splice(0) });
+    if (this.items.length > 0) {
+      const footnotes = this.buildPageFootnotes();
+      this.pages.push({ items: this.items.splice(0), footnotes });
+    }
     this.pageIndex++;
     this.colIndex = 0;
     this.y = this.insets().topPx;
@@ -263,6 +427,8 @@ class Flow {
     this.autoBreak = auto;
     this.zones.length = 0;
     this.bands.length = 0;
+    this.pageFootnoteIds.length = 0;
+    this.pageFootnoteHeight = 0;
   }
 
   /** Close the current column and continue at the top of the next one — a
@@ -385,8 +551,9 @@ class Flow {
     // is a fresh push, a split tail, or a re-placed keepNext block).
     this.dodgeBands();
     const before = this.spacingBefore(laid);
+    const extraFnH = this.extraFootnoteHeightFor(laid);
     // Both spans are relative to this.y: the page bottom and the band top.
-    const room = Math.min(this.remaining(), this.bandCeiling() - this.y) - before;
+    const room = Math.min(this.remaining() - extraFnH, this.bandCeiling() - this.y) - before;
     // `room` is already net of the before-margin, so the check adds the
     // extent alone — adding `before` here too would count the margin twice
     // and evict blocks Word keeps (a picture paragraph with an 8px before on
@@ -416,6 +583,7 @@ class Flow {
     this.y += before + laid.heightPx;
     this.prevAfter = laid.kind === "paragraph" ? laid.afterPx : 0;
     this.firstOnPage = false;
+    this.registerFootnotes(laid);
     if (laid.kind === "paragraph") this.registerFloats(laid, yPx);
   }
 
@@ -452,6 +620,7 @@ class Flow {
       this.prevAfter = 0;
       this.firstOnPage = true;
     }
+    this.resyncFootnotes();
     return moved;
   }
 

--- a/packages/layout/src/layout-doc/inline.ts
+++ b/packages/layout/src/layout-doc/inline.ts
@@ -45,6 +45,12 @@ export interface LayoutPictureCrop {
  *  `toPx` (a numbering bullet's hop to the body text), the paragraph's
  *  `tabStops`, or the default grid (720 twips). */
 
+export interface LayoutInlineNoteRef {
+  kind: "footnote" | "endnote";
+  id: number;
+  ordinal: number;
+}
+
 export type LayoutInline =
   /** A `field` marker makes the text a dynamic page-number atom (w:fldSimple /
    *  complexField PAGE / NUMPAGES): the value only exists after pagination, so
@@ -59,6 +65,9 @@ export type LayoutInline =
        *  /commentRangeEnd): the painter tints the text's box (sorted, unique).
        *  Pure paint metadata — measuring and wrapping ignore it. */
       commentIds?: number[];
+      /** Note reference metadata (Word's FootnoteReference / EndnoteReference).
+       *  The paginator reads this to anchor footnotes to the page where this run lands. */
+      noteRef?: LayoutInlineNoteRef;
     }
   | { kind: "break" }
   | { kind: "tab"; toPx?: number }

--- a/packages/layout/src/layout-result.ts
+++ b/packages/layout/src/layout-result.ts
@@ -219,3 +219,22 @@ export type LaidOutBlock =
   | LaidOutGroup
   | LaidOutPlaceholder
   | LaidOutPageBreak;
+
+/** One laid footnote note at the bottom of a page. */
+export interface LaidOutFootnoteNote {
+  id: number;
+  ordinal: number;
+  stack: LaidOutStackItem[];
+  heightPx: number;
+}
+
+/** The footnote area at the bottom of a page: the separator line and notes. */
+export interface LaidOutFootnoteArea {
+  /** Page-local content-box Y coordinate where the separator starts. */
+  yPx: number;
+  /** Width of the footnote separator line in px (Word default: 192 px / 2 in). */
+  separatorWidthPx: number;
+  notes: LaidOutFootnoteNote[];
+  items: LaidOutStackItem[];
+  totalHeightPx: number;
+}


### PR DESCRIPTION
## Summary

This PR adds complete, end-to-end support for footnotes across the docen architecture:
- **Geometry & Pagination Engine (`@docen/layout`)**:
  - Adds `LayoutInlineNoteRef` metadata to inline layout.
  - Adds `LaidOutFootnoteNote` and `LaidOutFootnoteArea` layout result types.
  - Reserves vertical room at the bottom of pages for referenced footnotes (including Word's standard 192 px / 2 in separator line).
  - Handles line splitting and pagination so that notes land on the exact page their reference appears on.
- **OOXML Projection (`@docen/docx`)**:
  - Attaches `noteRef` metadata on footnote reference runs in body paragraphs.
  - Handles `<w:footnoteRef/>` mark runs inside footnote definitions with matching superscript ordinals.
  - Projects `doc.footnotes` into `footnoteDefinitions: Map<number, readonly LayoutBlock[]>`.
- **Canvas Painter (`@docen/core`)**:
  - Implements `paintFootnotes` to draw the Word separator line and all laid footnote paragraph blocks on the Leafer canvas.
- **Editor & Interaction (`@docen/editor`)**:
  - Calls `paintFootnotes` in canvas stage repaint branches.
  - Passes footnote definitions into `layoutFlowSections`.
  - Updates `dirtyPagesOf` structural equality to re-render pages when footnotes change.
  - Adds "Previous Footnote" navigation action to ribbon References menu and editor commands with en/zh translations.
  - Adds sample footnote to the demo showcase document.

## Testing & Quality Assurance
- [x] `pnpm check` (`vp check --fix`) passes with 0 errors.
- [x] All 394 tests pass across `@docen/layout`, `@docen/docx`, and `@docen/editor`.
- [x] `pnpm build` compiles and packages all packages cleanly.
- [x] Conforms to coding and architecture conventions in `CONTRIBUTING.md` and `CLAUDE.md`.