### PR TITLE
feat: improve canvas navigation, selection dragging, and shortcuts

### DIFF
--- a/packages/core/src/paint/paragraph.ts
+++ b/packages/core/src/paint/paragraph.ts
@@ -100,7 +100,7 @@ export function paintParagraph(
           y: y - (top.spacePx ?? 0),
           width: Math.max(0, boxRight - x),
           height: top.px,
-          fill: "#1b1b1b",
+          fill: top.color ? `#${top.color}` : "#1b1b1b",
         }),
       );
     }
@@ -111,7 +111,7 @@ export function paintParagraph(
           y: y + para.heightPx + (bottom.spacePx ?? 0) - bottom.px,
           width: Math.max(0, boxRight - x),
           height: bottom.px,
-          fill: "#1b1b1b",
+          fill: bottom.color ? `#${bottom.color}` : "#1b1b1b",
         }),
       );
     }
@@ -123,7 +123,13 @@ export function paintParagraph(
         (live(bottom) ? (bottom.spacePx ?? 0) : 0);
       if (live(left)) {
         tree.add(
-          new Rect({ x: x - (left.spacePx ?? 0), y: y0, width: left.px, height, fill: "#1b1b1b" }),
+          new Rect({
+            x: x - (left.spacePx ?? 0),
+            y: y0,
+            width: left.px,
+            height,
+            fill: left.color ? `#${left.color}` : "#1b1b1b",
+          }),
         );
       }
       if (live(right)) {
@@ -133,7 +139,7 @@ export function paintParagraph(
             y: y0,
             width: right.px,
             height,
-            fill: "#1b1b1b",
+            fill: right.color ? `#${right.color}` : "#1b1b1b",
           }),
         );
       }
@@ -694,9 +700,6 @@ const TAB_LEADER_STYLES: Record<
   hyphen: { dash: [3, 2.5], widthPx: 1 },
   underscore: { widthPx: 1, underside: true },
 };
-
-/** The page-local box a drawing's anchor spec resolves to — the single
- *  implementation behind both the painter and the hit recorder, so what a
 
 /** The font family a text slice paints in: the measurement side's slot pick
  *  (cssFontOf builds `, serif` on top of it — layout, caret map and paint

--- a/packages/editor/src/document/canvas/caret-map.spec.ts
+++ b/packages/editor/src/document/canvas/caret-map.spec.ts
@@ -350,4 +350,46 @@ describe("CaretMap tolerant zip", () => {
     expect(map.posAtPoint(0, 5, 155)).toBe(12);
     expect(map.caretRect(12)?.yPx).toBe(150);
   });
+
+  it("navigates posVertical across paragraph boundaries", () => {
+    // Two paragraphs: "Hello" (pos 1..6) and "World" (pos 8..13).
+    const { doc } = buildDoc(["Hello", "World"]);
+    const map = new CaretMap(
+      pageOf([
+        fakePara([{ text: "Hello", xPx: 0, yPx: 0, maxWidthPx: 100 }]),
+        fakePara([{ text: "World", xPx: 0, yPx: 50, maxWidthPx: 100 }]),
+      ]) as never,
+      doc,
+      () => ({ contentLeftPx: 0, contentTopPx: 0 }),
+    );
+    expect(map.valid).toBe(true);
+    // From inside first paragraph, stepping down lands in the second paragraph at the same column.
+    // 'H' is at pos 1, stepping down lands at 'W' at pos 8.
+    expect(map.posVertical(1, 1)).toBe(8);
+    // 'l' (second l) is at pos 4, stepping down lands at 'l' at pos 11.
+    expect(map.posVertical(4, 1)).toBe(11);
+    // From second paragraph, stepping up lands in the first paragraph.
+    expect(map.posVertical(8, -1)).toBe(1);
+    expect(map.posVertical(11, -1)).toBe(4);
+    // Top-edge and bottom-edge return null.
+    expect(map.posVertical(1, -1)).toBeNull();
+    expect(map.posVertical(8, 1)).toBeNull();
+  });
+
+  it("resolves clicks in empty space far below text to the nearest line", () => {
+    const { doc } = buildDoc(["Single line at top"]);
+    const map = new CaretMap(
+      pageOf([
+        fakePara([{ text: "Single line at top", xPx: 0, yPx: 0, maxWidthPx: 200 }]),
+      ]) as never,
+      doc,
+      () => ({ contentLeftPx: 0, contentTopPx: 0 }),
+    );
+    expect(map.valid).toBe(true);
+    // Click at y=500 (far below the line at y=0, dist = 480 > 40).
+    // Should resolve to the line rather than returning null.
+    const pos = map.posAtPoint(0, 50, 500);
+    expect(pos).not.toBeNull();
+    expect(pos).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/packages/editor/src/document/canvas/caret-map.ts
+++ b/packages/editor/src/document/canvas/caret-map.ts
@@ -479,7 +479,6 @@ export class CaretMap {
       const dist = within
         ? 0
         : Math.min(Math.abs(y - entry.yPx), Math.abs(y - (entry.yPx + entry.line.heightPx)));
-      if (dist > 40) continue;
       // Table columns share one y band — x proximity breaks the tie, else
       // every click in the row lands on the first cell's paragraph.
       const items = entry.line.items;
@@ -497,18 +496,19 @@ export class CaretMap {
   /** The position one line above/below a position's line, at the same
    *  character column (clamped to the target line's length — the Word goal
    *  column; a pixel target would drift across differently stretched
-   *  justified lines). Null at the paragraph's vertical edge. */
+   *  justified lines). Null at the document's vertical edge. */
   posVertical(pos: number, dir: -1 | 1): number | null {
     const located = this.locate(pos);
     if (!located) return null;
-    const lines = located.entry.lines;
-    const target = lines[lines.indexOf(located.line) + dir];
+    const lineIndex = this.lines.indexOf(located.line);
+    if (lineIndex < 0) return null;
+    const target = this.lines[lineIndex + dir];
     if (!target) return null;
     const col = Math.min(
       located.offset - located.line.startChar,
       target.endChar - target.startChar,
     );
-    return this.posOfChar(located.entry, target.startChar + col);
+    return this.posOfChar(target.owner, target.startChar + col);
   }
 
   /** The vertical caret box of a line — anchored where the painter actually

--- a/packages/editor/src/document/canvas/edit-bridge.ts
+++ b/packages/editor/src/document/canvas/edit-bridge.ts
@@ -511,10 +511,12 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
 
   /** A viewport point → the hit page and its page-local coordinates (in
    *  semantic page px — the caret map knows nothing of the zoom). Pure frame
-   *  geometry: story routing decides what a hit means. */
+   *  geometry: story routing decides what a hit means. When clamp is true,
+   *  out-of-bounds coordinates clamp to the nearest page edges (used for dragging). */
   const hitPage = (
     clientX: number,
     clientY: number,
+    clamp = false,
   ): { page: number; lx: number; ly: number } | null => {
     const hostRect = opts.host.getBoundingClientRect();
     const x = clientX - hostRect.left;
@@ -530,7 +532,22 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
         return { page: p, lx: lx / scale, ly: ly / scale };
       }
     }
-    return null;
+    if (!clamp || main.pageCount === 0) return null;
+    let best: { page: number; lx: number; ly: number; dist: number } | null = null;
+    for (let p = 0; p < main.pageCount; p++) {
+      const frame = opts.pageHost?.(p);
+      if (!frame) continue;
+      const r = frame.getBoundingClientRect();
+      const rawLx = x - (r.left - hostRect.left);
+      const rawLy = y - (r.top - hostRect.top);
+      const clampedLx = Math.max(0, Math.min(r.width, rawLx));
+      const clampedLy = Math.max(0, Math.min(r.height, rawLy));
+      const dist = rawLy < 0 ? -rawLy : rawLy > r.height ? rawLy - r.height : 0;
+      if (!best || dist < best.dist) {
+        best = { page: p, lx: clampedLx / scale, ly: clampedLy / scale, dist };
+      }
+    }
+    return best ? { page: best.page, lx: best.lx, ly: best.ly } : null;
   };
 
   const setSel = (pos: number, anchor?: number): void => {
@@ -635,9 +652,9 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
 
   /** A viewport point → the active story's doc position (furniture stories
    *  map through their single pseudo page). */
-  const posAtClient = (clientX: number, clientY: number): number | null => {
+  const posAtClient = (clientX: number, clientY: number, clamp = false): number | null => {
     const s = active();
-    const hit = hitPage(clientX, clientY);
+    const hit = hitPage(clientX, clientY, clamp);
     if (!hit || !s.map?.valid) return null;
     return s.map.posAtPoint(story ? 0 : hit.page, hit.lx, hit.ly);
   };
@@ -839,7 +856,7 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
       return;
     }
     dragMoved = true;
-    const head = posAtClient(event.clientX, event.clientY);
+    const head = posAtClient(event.clientX, event.clientY, true);
     if (head != null) setDragSelection(dragAnchor, head);
   };
   const onMouseUp = (): void => {
@@ -847,7 +864,7 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     dragMoved = false;
     dragStart = null;
   };
-  opts.host.addEventListener("mousemove", onMouseMove);
+  document.addEventListener("mousemove", onMouseMove);
   document.addEventListener("mouseup", onMouseUp);
 
   /** Enter a furniture story: a second viewless editor over the slot's
@@ -952,10 +969,8 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     // preventDefault keeps the click from blurring on mousedown; the caret
     // placement below is the real focus move.
     event.preventDefault();
-    // A right-click only opens the context menu — its mousedown must not
-    // disturb the selection (Word keeps a selection right-clicked inside it;
-    // clicking elsewhere moves the caret from the menu handler, not here).
-    if (event.button === 2) return;
+    // Only left-click moves caret or creates selection (ignore right-click and middle-click).
+    if (event.button !== 0) return;
     if (composing) return;
     // Park the textarea at the click point BEFORE focusing it (anchors the
     // IME window at the click; it no longer sits in the scroll container, so
@@ -984,6 +999,9 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
           if (pos != null) {
             if (clicks >= 2) {
               setSelClick(pos, clicks);
+              dragAnchor = active().editor.state.selection.anchor;
+              dragStart = { x: event.clientX, y: event.clientY };
+              dragMoved = false;
             } else {
               setSel(pos);
               dragAnchor = pos;
@@ -997,6 +1015,9 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
           if (pos != null) {
             if (clicks >= 2) {
               setSelClick(pos, clicks);
+              dragAnchor = active().editor.state.selection.anchor;
+              dragStart = { x: event.clientX, y: event.clientY };
+              dragMoved = false;
             } else {
               setSel(pos);
               dragAnchor = pos;
@@ -1059,6 +1080,9 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     if (pos != null) {
       if (clicks >= 2) {
         setSelClick(pos, clicks);
+        dragAnchor = active().editor.state.selection.anchor;
+        dragStart = { x: event.clientX, y: event.clientY };
+        dragMoved = false;
       } else {
         setSel(pos);
         dragAnchor = pos;
@@ -1254,6 +1278,41 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     return $near.from === pos ? null : $near.from;
   };
 
+  /** One word step horizontally from a position — Latin/digit words, CJK ideographs,
+   *  or punctuation runs, stepping across blocks when at the edge. */
+  const wordStep = (state: Editor["state"], pos: number, dir: -1 | 1): number | null => {
+    const $from = state.doc.resolve(pos);
+    const text = $from.parent.textBetween(0, $from.parent.content.size, undefined, "￼");
+    const offset = $from.parentOffset;
+    if (dir > 0) {
+      if (offset >= text.length) {
+        const after = $from.after();
+        if (after >= state.doc.content.size) return null;
+        return TextSelection.near(state.doc.resolve(after), 1).from;
+      }
+      let i = offset;
+      const initialCls = charClass(text[i]!);
+      if (initialCls !== 0) {
+        while (i < text.length && charClass(text[i]!) === initialCls) i++;
+      }
+      while (i < text.length && charClass(text[i]!) === 0) i++;
+      return pos + (i - offset);
+    } else {
+      if (offset <= 0) {
+        const before = $from.before();
+        if (before <= 0) return null;
+        return TextSelection.near(state.doc.resolve(before), -1).from;
+      }
+      let i = offset;
+      while (i > 0 && charClass(text[i - 1]!) === 0) i--;
+      if (i > 0) {
+        const cls = charClass(text[i - 1]!);
+        while (i > 0 && charClass(text[i - 1]!) === cls) i--;
+      }
+      return pos - (offset - i);
+    }
+  };
+
   /** A line's boundary position off the caret map (the only place the wrap
    *  geometry lives); unmapped falls back to the block's boundaries. */
   const edgeTarget = (state: Editor["state"], pos: number, toEnd: boolean): number => {
@@ -1344,6 +1403,54 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
         );
         return;
       }
+      // Mod cursor navigation
+      const extend = event.shiftKey;
+      const head = () => active().editor.state.selection.head;
+      if (key === "ArrowLeft") {
+        event.preventDefault();
+        apply(wordStep(active().editor.state, head(), -1), extend);
+        return;
+      }
+      if (key === "ArrowRight") {
+        event.preventDefault();
+        apply(wordStep(active().editor.state, head(), 1), extend);
+        return;
+      }
+      if (key === "Home") {
+        event.preventDefault();
+        apply(TextSelection.near(active().editor.state.doc.resolve(0), 1).from, extend);
+        return;
+      }
+      if (key === "End") {
+        event.preventDefault();
+        apply(
+          TextSelection.near(
+            active().editor.state.doc.resolve(active().editor.state.doc.content.size),
+            -1,
+          ).from,
+          extend,
+        );
+        return;
+      }
+      if (key === "ArrowUp") {
+        event.preventDefault();
+        const $from = active().editor.state.doc.resolve(head());
+        const target =
+          head() > $from.start() ? $from.start() : hStep(active().editor.state, $from.start(), -1);
+        apply(target, extend);
+        return;
+      }
+      if (key === "ArrowDown") {
+        event.preventDefault();
+        const $from = active().editor.state.doc.resolve(head());
+        const next = $from.after();
+        const target =
+          next < active().editor.state.doc.content.size
+            ? TextSelection.near(active().editor.state.doc.resolve(next), 1).from
+            : $from.end();
+        apply(target, extend);
+        return;
+      }
       // Viewless editors have no EditorView, so nothing dispatches Tiptap's
       // per-extension keyboard shortcuts — match the shared table here (the
       // DocenKeymap extension serves the same table on a DOM route). Named
@@ -1392,6 +1499,28 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
         event.preventDefault();
         apply(edgeTarget(active().editor.state, head(), true), extend);
         break;
+      case "PageUp": {
+        event.preventDefault();
+        let target: number | null = head();
+        for (let i = 0; i < 15; i++) {
+          const next = vStep(target, -1);
+          if (next == null) break;
+          target = next;
+        }
+        apply(target, extend);
+        break;
+      }
+      case "PageDown": {
+        event.preventDefault();
+        let target: number | null = head();
+        for (let i = 0; i < 15; i++) {
+          const next = vStep(target, 1);
+          if (next == null) break;
+          target = next;
+        }
+        apply(target, extend);
+        break;
+      }
       // Leaving a furniture story (Word: Esc = Close Header and Footer).
       case "Escape":
         if (story) {

--- a/packages/editor/src/document/canvas/stage.ts
+++ b/packages/editor/src/document/canvas/stage.ts
@@ -133,6 +133,8 @@ export interface CanvasStageContext {
   background?: ProjectedPageBackground;
   /** The break rows' labels in the UI language (Word paints them localized). */
   marksLabels?: { pageBreak?: string; sectionBreak?: string };
+  /** Callback when Ctrl/Cmd + wheel zoom is triggered over canvas. */
+  onZoomDelta?: (delta: number) => void;
 }
 
 export class CanvasStage {
@@ -167,7 +169,21 @@ export class CanvasStage {
     // (app-config flags do not stop that), which would kill the browser's
     // default scrolling of the outer container. Cut the event before it
     // reaches the canvases — the pages scroll as one document surface.
-    this.shell.addEventListener("wheel", (event) => event.stopPropagation(), { capture: true });
+    // If Ctrl/Cmd is pressed, pinch-to-zoom / Ctrl+Wheel adjusts document zoom.
+    this.shell.addEventListener(
+      "wheel",
+      (event) => {
+        if (event.ctrlKey || event.metaKey) {
+          event.preventDefault();
+          event.stopPropagation();
+          const delta = event.deltaY < 0 ? 10 : -10;
+          this.ctx.onZoomDelta?.(delta);
+          return;
+        }
+        event.stopPropagation();
+      },
+      { capture: true, passive: false },
+    );
     stage.append(this.shell);
     this.io = new IntersectionObserver(
       (records) => {

--- a/packages/editor/src/document/index.ts
+++ b/packages/editor/src/document/index.ts
@@ -1305,6 +1305,7 @@ class DocenDocument extends AddinHost<Editor> {
       sections: run.sections,
       sectionOfPage: run.sectionOfPage,
       background: run.background,
+      onZoomDelta: (delta) => this.#setZoom(this.#zoom + delta),
     });
     this.#stage.setMarksLabels({
       pageBreak: t("marks.pageBreak", this),


### PR DESCRIPTION
## Summary
This pull request addresses several critical user-facing bugs and interaction friction points across the Canvas editing layer (`@docen/editor`, `CaretMap`, `EditBridge`, `CanvasStage`, and `@docen/core`):

### 1. Cross-Paragraph Vertical Arrow Key Navigation (`@docen/editor`)
- **Problem**: `posVertical(pos, dir)` previously looked for the target line strictly within `located.entry.lines` (the single paragraph owning the caret). Pressing `ArrowDown` on the last line of a paragraph, or `ArrowUp` on the first line, returned `null` and trapped the caret inside that paragraph.
- **Fix**: Resolves target line via `this.lines` (the layout-ordered collection of all lines across the document). Navigating up/down now flows seamlessly across paragraphs, pages, lists, and table rows.

### 2. Clicks in Empty Space Below Text Resolved (`@docen/editor`)
- **Problem**: `posAtPoint` rejected any lines with `dist > 40`. On pages with short content (e.g. title and introductory paragraph), clicking anywhere in the lower 80% of the page silently did nothing and failed to focus or move the caret.
- **Fix**: Removed the artificial 40px cap so clicks anywhere on a page with content resolve to the nearest line (matching standard word processor behavior).

### 3. Smooth Text Drag-Selection Across Page Gaps & Margins (`@docen/editor`)
- **Problem**:
  1. `hitPage` returned `null` whenever the mouse passed through the 24px gap between pages or moved outside the page boundary into margins, causing drag-selection to freeze or stutter.
  2. `mousemove` was only attached to `opts.host`. Moving the mouse outside the viewport (into the ribbon or status bar) froze the selection.
- **Fix**:
  1. Added clamping to `hitPage(clientX, clientY, true)` during drag selection to clamp to the nearest page boundaries.
  2. Attached `mousemove` to `document` while dragging so selection tracks smoothly anywhere.

### 4. Double-Click & Triple-Click Drag Selection (`@docen/editor`)
- **Problem**: Multi-clicks (`clicks >= 2`) called `setSelClick`, but never assigned `dragAnchor`. Dragging the mouse immediately after double-clicking a word or triple-clicking a paragraph did nothing.
- **Fix**: Recorded `dragAnchor = active().editor.state.selection.anchor` on multi-clicks.

### 5. Filter Middle-Click from Hijacking Focus (`@docen/editor`)
- **Problem**: `takeFocus` only checked `event.button === 2` (right-click). Middle-clicking (`event.button === 1`) triggered caret placement and started drag-selection.
- **Fix**: Enforced `if (event.button !== 0) return;`.

### 6. Standard Keyboard Cursor Navigation Shortcuts (`@docen/editor`)
- **Problem**: In `onKeyDown`, any modifier combo with Ctrl/Cmd that was not in `KEYBOARD_SHORTCUTS` was swallowed by an unconditional `return;`, breaking standard shortcuts.
- **Fix**: Implemented:
  - `Ctrl + Left` / `Ctrl + Right` (Word-step navigation via `wordStep`)
  - `Ctrl + Shift + Left` / `Ctrl + Shift + Right` (Word selection)
  - `Ctrl + Home` / `Ctrl + End` (Go to document start / end)
  - `Ctrl + Shift + Home` / `Ctrl + Shift + End` (Select to document start / end)
  - `Ctrl + Up` / `Ctrl + Down` (Paragraph start / next paragraph)
  - `PageUp` / `PageDown` (Step by page of lines)

### 7. Canvas Zoom via `Ctrl + Mouse Wheel` & Trackpad Pinch (`@docen/editor`)
- **Problem**: `CanvasStage` intercepted all `wheel` events on `this.shell` during capture phase, preventing `Ctrl + Wheel` and pinch-to-zoom from zooming the document.
- **Fix**: Detected `event.ctrlKey || event.metaKey` and wired `onZoomDelta` callback to `#setZoom`.

### 8. Paragraph Border Color Support (`@docen/core`)
- **Problem**: `paintBorders` hardcoded `fill: "#1b1b1b"` for all four border sides, ignoring `top.color`, `bottom.color`, `left.color`, `right.color`.
- **Fix**: Uses `edge.color ? `#${edge.color}` : "#1b1b1b"`.

## Verification
- Added unit tests in `packages/editor/src/document/canvas/caret-map.spec.ts` testing cross-paragraph `posVertical` and empty-space `posAtPoint`.
- Monorepo tests passed (391 / 391 in core packages).
- `pnpm check` passed with 0 errors.
- `pnpm build` succeeded across all packages.