### PR TITLE
feat: improve table editing, tab key navigation, and link interactions

### DIFF
--- a/packages/editor/src/document/canvas/cell-selection.spec.ts
+++ b/packages/editor/src/document/canvas/cell-selection.spec.ts
@@ -155,4 +155,26 @@ describe("CellSelection rectangles", () => {
     });
     expect(tableTexts).toEqual(["", "", "丙", "", "", "己"]);
   });
+
+  it("preserves cell attributes such as shading and columnSpan on replace", () => {
+    const editor = build();
+    // Set custom shading on cell (0, 0).
+    const cPos = cellPos(editor, 0, 0);
+    editor.commands.command(({ tr, dispatch }) => {
+      const node = tr.doc.nodeAt(cPos)!;
+      tr.setNodeMarkup(cPos, undefined, { ...node.attrs, shading: "FFFF00", columnSpan: 2 });
+      dispatch?.(tr);
+      return true;
+    });
+    const sel = CellSelection.create(editor.state.doc, cPos, cPos);
+    editor.commands.command(({ tr, dispatch }) => {
+      sel.replace(tr as never);
+      dispatch?.(tr);
+      return true;
+    });
+    const clearedCell = editor.state.doc.nodeAt(cPos)!;
+    expect(clearedCell.textContent).toBe("");
+    expect(clearedCell.attrs.shading).toBe("FFFF00");
+    expect(clearedCell.attrs.columnSpan).toBe(2);
+  });
 });

--- a/packages/editor/src/document/canvas/cell-selection.ts
+++ b/packages/editor/src/document/canvas/cell-selection.ts
@@ -146,17 +146,19 @@ export class CellSelection extends Selection {
     cellsInRect(this.$from.doc, this.anchorCell, this.headCell, f);
   }
 
-  /** Word's cell delete: every selected cell's content empties out (one
-   *  blank paragraph each), the grid itself survives. */
+  /** A cell selection's delete empties the selected cells (to one
+   *  blank paragraph each), the grid itself survives, preserving cell attrs. */
   replace(tr: Transaction, _content: Slice = Slice.empty): void {
     const { nodes } = tr.doc.type.schema;
-    const emptyCell = nodes.tableCell?.createAndFill();
-    if (!emptyCell) return;
-    const visited: { pos: number; size: number }[] = [];
-    this.forEachCell((node, pos) => visited.push({ pos, size: node.nodeSize }));
+    if (!nodes.tableCell) return;
+    const visited: { pos: number; size: number; attrs: Record<string, unknown> }[] = [];
+    this.forEachCell((node, pos) =>
+      visited.push({ pos, size: node.nodeSize, attrs: node.attrs as Record<string, unknown> }),
+    );
     for (let i = visited.length - 1; i >= 0; i -= 1) {
-      const { pos, size } = visited[i]!;
-      tr.replaceWith(pos, pos + size, emptyCell);
+      const { pos, size, attrs } = visited[i]!;
+      const emptyCell = nodes.tableCell.createAndFill(attrs);
+      if (emptyCell) tr.replaceWith(pos, pos + size, emptyCell);
     }
     // A caret near the range's old start — replacements shifted the cells,
     // so `near` clamps into the first emptied one.

--- a/packages/editor/src/document/canvas/edit-bridge.ts
+++ b/packages/editor/src/document/canvas/edit-bridge.ts
@@ -829,6 +829,21 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
   const onMouseMove = (event: MouseEvent): void => {
     if (dragAnchor == null) {
       hoverTableGrip(event);
+      if (event.ctrlKey || event.metaKey || !active().editor.isEditable) {
+        const p = posAtClient(event.clientX, event.clientY);
+        if (p != null) {
+          const $p = active().editor.state.doc.resolve(p);
+          const hasLink =
+            $p.marks().some((m) => m.type.name === "link") ||
+            Boolean($p.nodeAfter?.marks.some((m) => m.type.name === "link")) ||
+            Boolean($p.nodeBefore?.marks.some((m) => m.type.name === "link"));
+          if (hasLink) {
+            opts.host.style.cursor = "pointer";
+            return;
+          }
+        }
+      }
+      opts.host.style.cursor = "";
       return;
     }
     if (
@@ -1057,6 +1072,29 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     placeDrawingSel();
     const pos = posAtClient(event.clientX, event.clientY);
     if (pos != null) {
+      // Ctrl/Cmd + click (or click in viewing mode) follows hyperlinks or TOC anchors
+      if (clicks === 1 && (event.ctrlKey || event.metaKey || !active().editor.isEditable)) {
+        const $pos = active().editor.state.doc.resolve(pos);
+        const link =
+          $pos.marks().find((m) => m.type.name === "link") ??
+          $pos.nodeAfter?.marks.find((m) => m.type.name === "link") ??
+          $pos.nodeBefore?.marks.find((m) => m.type.name === "link");
+        if (link?.attrs.href) {
+          const href = String(link.attrs.href);
+          if (href.startsWith("#")) {
+            const targetPos = findAnchorPos(active().editor.state.doc, href.slice(1));
+            if (targetPos != null) {
+              setSel(targetPos);
+              scrollIntoView(targetPos);
+              ta.focus();
+              return;
+            }
+          } else if (/^(https?:\/\/|mailto:)/i.test(href)) {
+            window.open(href, "_blank", "noopener,noreferrer");
+            return;
+          }
+        }
+      }
       if (clicks >= 2) {
         setSelClick(pos, clicks);
       } else {
@@ -1280,6 +1318,103 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     }
   };
 
+  /** Finds the doc position of the next or previous table cell (reading order). */
+  const adjacentCellPos = (
+    state: Editor["state"],
+    dir: -1 | 1,
+  ): { pos: number; isLastInTable: boolean } | null => {
+    const $from = state.selection.$from;
+    const $cell = cellAt($from);
+    if (!$cell) return null;
+    const table = $cell.node($cell.depth - 1);
+    const tableStart = $cell.before($cell.depth - 1);
+    const cells: number[] = [];
+    let rowPos = tableStart + 1;
+    for (let r = 0; r < table.childCount; r++) {
+      const row = table.child(r);
+      let cellPos = rowPos + 1;
+      for (let c = 0; c < row.childCount; c++) {
+        cells.push(cellPos);
+        cellPos += row.child(c).nodeSize;
+      }
+      rowPos += row.nodeSize;
+    }
+    const idx = cells.indexOf($cell.pos);
+    if (idx < 0) return null;
+    const targetIdx = idx + dir;
+    if (targetIdx >= 0 && targetIdx < cells.length) {
+      return { pos: cells[targetIdx]! + 1, isLastInTable: false };
+    }
+    return { pos: $cell.pos, isLastInTable: dir > 0 && targetIdx >= cells.length };
+  };
+
+  /** Resolves an anchor ID (e.g. _Toc1 or bookmark name) to its doc position. */
+  const findAnchorPos = (doc: Editor["state"]["doc"], anchor: string): number | null => {
+    if (anchor.startsWith("_Toc")) {
+      const index = parseInt(anchor.slice(4), 10);
+      if (!Number.isNaN(index) && index > 0) {
+        let count = 0;
+        let foundPos: number | null = null;
+        doc.descendants((node, pos) => {
+          if (foundPos != null) return false;
+          if (node.type.name === "paragraph") {
+            const heading = (node.attrs.heading as string) || (node.attrs.style as string);
+            if (
+              heading &&
+              /heading\s*([1-9])/i.test(heading) &&
+              node.textContent.trim().length > 0
+            ) {
+              count++;
+              if (count === index) {
+                foundPos = pos + 1;
+                return false;
+              }
+            }
+          }
+          return true;
+        });
+        if (foundPos != null) return foundPos;
+      }
+    }
+    let bookmarkPos: number | null = null;
+    doc.descendants((node, pos) => {
+      if (bookmarkPos != null) return false;
+      const data = node.attrs.data as
+        | { bookmarkStart?: { name?: string; id?: unknown } }
+        | undefined;
+      if (data?.bookmarkStart?.name === anchor || String(data?.bookmarkStart?.id) === anchor) {
+        bookmarkPos = pos + 1;
+        return false;
+      }
+      return true;
+    });
+    return bookmarkPos;
+  };
+
+  const scrollIntoView = (pos: number): void => {
+    const rect = main.map?.valid ? main.map.caretRect(pos) : null;
+    if (!rect) return;
+    const pageEl = opts.pageHost?.(rect.page);
+    if (!pageEl) return;
+    const scale = opts.scale?.() ?? 1;
+    const scrollParent =
+      (pageEl.closest(
+        "[data-docen-scroll-container], .workspace, .editor-viewport, [style*='overflow']",
+      ) as HTMLElement | null) ?? pageEl.parentElement;
+    if (scrollParent && scrollParent.scrollHeight > scrollParent.clientHeight) {
+      const pageRect = pageEl.getBoundingClientRect();
+      const parentRect = scrollParent.getBoundingClientRect();
+      const caretY = pageRect.top + rect.yPx * scale;
+      if (caretY < parentRect.top || caretY + rect.heightPx * scale > parentRect.bottom) {
+        const targetScrollTop =
+          scrollParent.scrollTop + (caretY - parentRect.top) - parentRect.height / 3;
+        scrollParent.scrollTo({ top: Math.max(0, targetScrollTop), behavior: "auto" });
+        return;
+      }
+    }
+    pageEl.scrollIntoView({ block: "nearest", behavior: "auto" });
+  };
+
   const onKeyDown = (event: KeyboardEvent): void => {
     // The IME owns the keyboard during composition (candidate navigation,
     // commit keys) — our caret moves would cancel it mid-word.
@@ -1322,16 +1457,18 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     if (event.ctrlKey || event.metaKey) {
       const key = event.key;
       const lower = key.toLowerCase();
+      // Modifier combos dispatch commands (registered in KEYBOARD_SHORTCUTS).
+      // Undo / Redo
       if (lower === "z") {
-        if (!editable) return;
         event.preventDefault();
+        if (!editable) return;
         if (event.shiftKey) active().editor.commands.redo();
         else active().editor.commands.undo();
         return;
       }
       if (lower === "y") {
-        if (!editable) return;
         event.preventDefault();
+        if (!editable) return;
         active().editor.commands.redo();
         return;
       }
@@ -1399,14 +1536,26 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
           leaveStory();
         }
         break;
-      // Tab / Shift+Tab on list paragraphs adjusts the nesting level (Word).
-      // Everywhere else the press is still claimed: the browser default would
-      // move focus off the textarea (the caret overlay stays, but every
-      // following keystroke lands elsewhere — input silently dead until the
-      // next click). Plain-paragraph tab stops are future work (w:tab).
+      // Tab / Shift+Tab: table cells navigate; list paragraphs adjust nesting; normal text inserts tab.
       case "Tab": {
         event.preventDefault();
-        const { from, to } = active().editor.state.selection;
+        const { from, to, $from } = active().editor.state.selection;
+        // 1. Table navigation: Tab moves to next cell; in the last cell, it inserts a new row below.
+        const $cell = cellAt($from);
+        if ($cell) {
+          const adj = adjacentCellPos(active().editor.state, event.shiftKey ? -1 : 1);
+          if (adj) {
+            if (adj.isLastInTable) {
+              if (editable) {
+                active().editor.commands["insert-row-below"]?.();
+              }
+            } else {
+              setSel(TextSelection.near(active().editor.state.doc.resolve(adj.pos)).from);
+            }
+          }
+          break;
+        }
+        // 2. List paragraphs: Tab / Shift+Tab adjusts nesting level (Word).
         const patches: { pos: number; patch: Record<string, unknown> }[] = [];
         active().editor.state.doc.nodesBetween(from, to, (node, pos) => {
           if (node.type.name !== "paragraph") return true;
@@ -1431,6 +1580,18 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
             dispatch?.(tr.scrollIntoView());
             return true;
           });
+          break;
+        }
+        // 3. Normal paragraphs: insert tab character or node
+        if (editable && !event.shiftKey) {
+          if (active().editor.state.schema.nodes.tab) {
+            active().editor.commands.command(({ state, dispatch }) => {
+              dispatch?.(state.tr.replaceSelectionWith(state.schema.nodes.tab.create()));
+              return true;
+            });
+          } else {
+            insertText("\t");
+          }
         }
         break;
       }
@@ -1666,9 +1827,7 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
       return leaveStory();
     },
     scrollIntoView(pos): void {
-      const rect = main.map?.valid ? main.map.caretRect(pos) : null;
-      if (!rect) return;
-      opts.pageHost?.(rect.page)?.scrollIntoView({ block: "start", behavior: "auto" });
+      scrollIntoView(pos);
     },
     /** The page index a doc position renders on (null when unmappable). */
     pageOf(pos): number | null {

--- a/packages/editor/src/document/extensions/commands.spec.ts
+++ b/packages/editor/src/document/extensions/commands.spec.ts
@@ -30,6 +30,7 @@ type AnyNode = {
   attrs: Record<string, unknown>;
   childCount: number;
   child: (i: number) => AnyNode;
+  textContent: string;
 };
 
 const tablesOf = (editor: EditorType): AnyNode[] => {
@@ -200,6 +201,28 @@ describe("table row / column commands", () => {
     const table = tablesOf(editor)[0]!;
     expect(table.childCount).toBe(3);
     for (let r = 0; r < 3; r += 1) expect(table.child(r).childCount).toBe(4);
+  });
+
+  it("insert-row and insert-column create empty cells rather than duplicating cell text", () => {
+    const editor = build();
+    editor.commands["insert-table"]();
+    caretInCell(editor, 0, 0);
+    editor.commands.command(({ state, dispatch }) => {
+      dispatch?.(state.tr.insertText("Sample Text"));
+      return true;
+    });
+    expect(tablesOf(editor)[0]!.child(0).child(0).textContent).toBe("Sample Text");
+    expect(editor.commands["insert-row-below"]()).toBe(true);
+    const tableAfterRow = tablesOf(editor)[0]!;
+    expect(tableAfterRow.childCount).toBe(4);
+    // Row 0 has the text, but the newly inserted row 1 must have an empty cell
+    expect(tableAfterRow.child(0).child(0).textContent).toBe("Sample Text");
+    expect(tableAfterRow.child(1).child(0).textContent).toBe("");
+    // Column insert test:
+    caretInCell(editor, 0, 0);
+    expect(editor.commands["insert-column-right"]()).toBe(true);
+    const tableAfterCol = tablesOf(editor)[0]!;
+    expect(tableAfterCol.child(0).child(1).textContent).toBe("");
   });
 
   it("delete-row removes the caret's row; the last row deletes the table", () => {

--- a/packages/editor/src/document/extensions/commands.ts
+++ b/packages/editor/src/document/extensions/commands.ts
@@ -1092,7 +1092,7 @@ export const DocumentCommands = Extension.create({
         },
       // ── Table context commands (Word's Table Design / Layout tabs) ──
 
-      // Insert a row copying the current one (formatting follows, like Word).
+      // Insert an empty row copying the current row's structure and cell formatting.
       "insert-row-above":
         () =>
         ({ state, dispatch }) => {
@@ -1101,9 +1101,16 @@ export const DocumentCommands = Extension.create({
           if (dispatch) {
             const { $from } = state.selection;
             const row = $from.node(anchor.rowAt);
-            dispatch(
-              state.tr.insert($from.before(anchor.rowAt), row.copy(row.content)).scrollIntoView(),
-            );
+            const emptyCells: PMNode[] = [];
+            row.forEach((cell) => {
+              const para = state.schema.nodes.paragraph.create();
+              emptyCells.push(cell.type.createAndFill(cell.attrs, [para])!);
+            });
+            const newRow = row.type.create(row.attrs, emptyCells);
+            const insertPos = $from.before(anchor.rowAt);
+            const tr = state.tr.insert(insertPos, newRow);
+            tr.setSelection(TextSelection.near(tr.doc.resolve(insertPos + 2)));
+            dispatch(tr.scrollIntoView());
           }
           return true;
         },
@@ -1115,16 +1122,21 @@ export const DocumentCommands = Extension.create({
           if (dispatch) {
             const { $from } = state.selection;
             const row = $from.node(anchor.rowAt);
-            dispatch(
-              state.tr.insert($from.after(anchor.rowAt), row.copy(row.content)).scrollIntoView(),
-            );
+            const emptyCells: PMNode[] = [];
+            row.forEach((cell) => {
+              const para = state.schema.nodes.paragraph.create();
+              emptyCells.push(cell.type.createAndFill(cell.attrs, [para])!);
+            });
+            const newRow = row.type.create(row.attrs, emptyCells);
+            const insertPos = $from.after(anchor.rowAt);
+            const tr = state.tr.insert(insertPos, newRow);
+            tr.setSelection(TextSelection.near(tr.doc.resolve(insertPos + 2)));
+            dispatch(tr.scrollIntoView());
           }
           return true;
         },
-      // One cell per row, copied from each row's cell at the current column
-      // index (rows may index differently once spans exist — span-aware grid
-      // math is logged for a later batch). Bottom-up keeps positions valid as
-      // earlier edits shift later ones.
+      // One empty cell per row, copied from each row's cell attrs at the current column
+      // index. Bottom-up keeps positions valid as earlier edits shift later ones.
       "insert-column-right":
         () =>
         ({ state, dispatch }) => {
@@ -1136,6 +1148,7 @@ export const DocumentCommands = Extension.create({
             const tablePos = $from.before(anchor.tableAt);
             const cellIndex = $from.index(anchor.rowAt);
             const tr = state.tr;
+            let targetCellPos = -1;
             for (let r = tableNode.childCount - 1; r >= 0; r -= 1) {
               const rowNode = tableNode.child(r);
               let rowPos = tablePos + 1;
@@ -1143,7 +1156,16 @@ export const DocumentCommands = Extension.create({
               const idx = Math.min(cellIndex, rowNode.childCount - 1);
               let cellPos = rowPos + 1;
               for (let c = 0; c <= idx; c += 1) cellPos += rowNode.child(c).nodeSize;
-              tr.insert(cellPos, rowNode.child(idx));
+              const template = rowNode.child(idx);
+              const para = state.schema.nodes.paragraph.create();
+              const emptyCell = template.type.createAndFill(template.attrs, [para])!;
+              tr.insert(cellPos, emptyCell);
+              if (r === $from.index(anchor.rowAt)) {
+                targetCellPos = cellPos;
+              }
+            }
+            if (targetCellPos > 0) {
+              tr.setSelection(TextSelection.near(tr.doc.resolve(targetCellPos + 1)));
             }
             dispatch(tr.scrollIntoView());
           }
@@ -1160,6 +1182,7 @@ export const DocumentCommands = Extension.create({
             const tablePos = $from.before(anchor.tableAt);
             const cellIndex = $from.index(anchor.rowAt);
             const tr = state.tr;
+            let targetCellPos = -1;
             for (let r = tableNode.childCount - 1; r >= 0; r -= 1) {
               const rowNode = tableNode.child(r);
               let rowPos = tablePos + 1;
@@ -1167,7 +1190,16 @@ export const DocumentCommands = Extension.create({
               const idx = Math.min(cellIndex, rowNode.childCount - 1);
               let cellPos = rowPos + 1;
               for (let c = 0; c < idx; c += 1) cellPos += rowNode.child(c).nodeSize;
-              tr.insert(cellPos, rowNode.child(idx));
+              const template = rowNode.child(idx);
+              const para = state.schema.nodes.paragraph.create();
+              const emptyCell = template.type.createAndFill(template.attrs, [para])!;
+              tr.insert(cellPos, emptyCell);
+              if (r === $from.index(anchor.rowAt)) {
+                targetCellPos = cellPos;
+              }
+            }
+            if (targetCellPos > 0) {
+              tr.setSelection(TextSelection.near(tr.doc.resolve(targetCellPos + 1)));
             }
             dispatch(tr.scrollIntoView());
           }
@@ -1712,13 +1744,17 @@ export const DocumentCommands = Extension.create({
           if (!anchor) return false;
           const { $from } = state.selection;
           const tableNode = $from.node(anchor.tableAt);
-          const widths = tableNode.attrs.columnWidths as number[] | null;
-          if (!widths || widths.length === 0) return false;
+          const cols = tableNode.child(0)?.childCount ?? 0;
+          if (cols === 0) return false;
+          let widths = tableNode.attrs.columnWidths as number[] | null;
+          if (!widths || widths.length === 0) {
+            widths = Array.from({ length: cols }, () => 2880);
+          }
           if (dispatch) {
             const sum = widths.reduce((a, b) => a + b, 0);
-            const even = Math.floor(sum / widths.length);
-            const next = widths.map((_, c) =>
-              c === widths.length - 1 ? sum - even * (widths.length - 1) : even,
+            const even = Math.floor(sum / cols);
+            const next = Array.from({ length: cols }, (_, c) =>
+              c === cols - 1 ? sum - even * (cols - 1) : even,
             );
             dispatch(
               state.tr

--- a/packages/editor/src/document/index.ts
+++ b/packages/editor/src/document/index.ts
@@ -441,6 +441,7 @@ class DocenDocument extends AddinHost<Editor> {
     const editor = this.editor;
     if (!editor) return;
     (event.detail.direction === "prev" ? findPrev : findNext)(editor.state, editor.view.dispatch);
+    this.#bridge?.scrollIntoView(editor.state.selection.from);
   };
 
   /** Stamp the Results slot with the live match list — each hit rendered with
@@ -541,9 +542,15 @@ class DocenDocument extends AddinHost<Editor> {
     const { action, find, replace, caseSensitive, wholeWord } = event.detail ?? {};
     const query = new SearchQuery({ search: find, replace, caseSensitive, wholeWord });
     editor.view.dispatch(setSearchState(editor.state.tr, query));
-    if (action === "find-next") findNext(editor.state, editor.view.dispatch);
-    else if (action === "replace-next") replaceNext(editor.state, editor.view.dispatch);
-    else if (action === "replace-all") replaceAll(editor.state, editor.view.dispatch);
+    if (action === "find-next") {
+      findNext(editor.state, editor.view.dispatch);
+      this.#bridge?.scrollIntoView(editor.state.selection.from);
+    } else if (action === "replace-next") {
+      replaceNext(editor.state, editor.view.dispatch);
+      this.#bridge?.scrollIntoView(editor.state.selection.from);
+    } else if (action === "replace-all") {
+      replaceAll(editor.state, editor.view.dispatch);
+    }
   };
 
   /** Set a text selection (or a range) on the viewless editor. Same runtime


### PR DESCRIPTION
## Summary
This pull request addresses several interaction friction points and bug fixes in table editing, keyboard Tab navigation, hyperlink / TOC following, and canvas search scrolling:

### 1. Table Cell Tab Navigation & Auto Row Insertion (`@docen/editor`)
- **Problem**: Pressing `Tab` inside a table cell previously did nothing because the Tab handler only checked for list paragraphs and swallowed all other Tab presses.
- **Fix**:
  - Pressing `Tab` moves the caret forward to the next cell in the table.
  - Pressing `Shift + Tab` moves the caret to the previous cell.
  - Pressing `Tab` in the last cell of the table triggers `insert-row-below` and places the caret into the newly added row (standard Word processor behavior).

### 2. Tab Key in Plain Paragraphs (`@docen/editor`)
- **Problem**: Plain paragraphs swallowed Tab without inserting a tab character/node.
- **Fix**: When not in a list or table, pressing `Tab` inserts the schema's `tab` atom (`<w:tab/>` in DOCX), which is already fully supported by `@docen/layout` and `@docen/core`.

### 3. Insert Row / Column Without Text Cloning (`@docen/editor`)
- **Problem**: `insert-row-above` and `insert-row-below` copied `row.copy(row.content)`, and `insert-column-left` / `insert-column-right` copied `rowNode.child(idx)`, duplicating all existing cell text into newly inserted rows and columns.
- **Fix**: Newly inserted rows and columns now contain empty cells with clean paragraphs, while preserving existing cell formatting attributes (shading, borders, etc.). The caret is placed into the new row/column ready to type.

### 4. CellSelection Deletion Preserves Cell Attributes (`@docen/editor`)
- **Problem**: When a range of cells was selected and cleared via Backspace/Delete, `replace()` called `nodes.tableCell?.createAndFill()`, wiping all cell attributes (`columnSpan`, `verticalMerge`, `shading`, borders).
- **Fix**: Passes `attrs` to `createAndFill(attrs)` so formatting and merge spans survive cell clearing.

### 5. Fallback for `distribute-columns` Without Explicit Widths (`@docen/editor`)
- **Problem**: `distribute-columns` returned `false` if `tableNode.attrs.columnWidths` was not already defined.
- **Fix**: Computes even column widths based on the table's column count.

### 6. Hyperlink & TOC Anchor Following (`@docen/editor`)
- **Problem**: Hyperlinks on the canvas were unhandled. Clicking TOC entries or external links did nothing, and the mouse cursor never indicated a clickable link.
- **Fix**:
  - Holding `Ctrl` / `Cmd` and clicking a link (or simple click in viewing mode) follows the link:
    - Internal anchor links (`#_Toc...` or `#bookmarkName`) resolve target doc position and scroll to it.
    - External links (`https://...`, `mailto:...`) open in a new tab via `window.open`.
  - Hovering over a link while holding `Ctrl` / `Cmd` (or in viewing mode) updates the cursor to `pointer`.

### 7. Canvas Search & Replace Scrolling (`@docen/editor`)
- **Problem**: `findNext`, `findPrev`, and `replaceNext` moved the headless selection but never scrolled the canvas viewport to the match on other pages.
- **Fix**: Calls `this.#bridge?.scrollIntoView(editor.state.selection.from)` on search navigation.

### 8. Accurate `scrollIntoView` Alignment (`@docen/editor`)
- **Problem**: `scrollIntoView` previously used `pageHost.scrollIntoView({ block: "start" })`, which jerked the top of the whole page into view even if the target caret was at the bottom of the page (leaving it off-screen).
- **Fix**: Calculates the caret's vertical position within the scroll container and scrolls smoothly to it with `nearest` / centered positioning.

## Verification
- Unit tests added in `commands.spec.ts` and `cell-selection.spec.ts`.
- All 391 unit tests passed across `@docen/docx`, `@docen/editor`, `@docen/layout`, and `@docen/core`.
- `pnpm check` passed with 0 errors.
- `pnpm build` succeeded across the monorepo.