### PR TITLE
feat: improve list backspace, node deletion, paste, and formatting

### DIFF
--- a/packages/editor/src/document/canvas/edit-bridge.ts
+++ b/packages/editor/src/document/canvas/edit-bridge.ts
@@ -1099,6 +1099,34 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
           return true;
         }
       }
+      // Backspace at the start of a list item: outdent if nested, or clear list formatting (Word behavior).
+      const parent = $from.parent;
+      if (parent.type.name === "paragraph") {
+        const attrs = parent.attrs as Record<string, unknown>;
+        const isList = attrs.bullet != null || attrs.numbering != null;
+        if (isList) {
+          const curLevel =
+            (attrs.bullet as { level?: number } | null | undefined)?.level ??
+            (attrs.numbering as { level?: number } | null | undefined)?.level ??
+            0;
+          if (curLevel > 0) {
+            const patch = listLevelStepPatch(attrs, -1);
+            if (patch) {
+              dispatch?.(state.tr.setNodeMarkup($from.before(), undefined, { ...attrs, ...patch }));
+              return true;
+            }
+          } else {
+            dispatch?.(
+              state.tr.setNodeMarkup($from.before(), undefined, {
+                ...attrs,
+                bullet: null,
+                numbering: null,
+              }),
+            );
+            return true;
+          }
+        }
+      }
       // Same runtime PM instance (single .pnpm dir); the cast bridges the
       // dual d.ts identity between this package's @tiptap/pm and the engine's.
       return joinBackward(state as never, dispatch);
@@ -1300,6 +1328,19 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
         });
         return;
       }
+      if (sel instanceof NodeSelection) {
+        event.preventDefault();
+        active().editor.commands.command(({ tr, dispatch }) => {
+          if (dispatch) {
+            tr.deleteSelection();
+            dispatch(tr);
+          }
+          return true;
+        });
+        selDrawing = null;
+        placeDrawingSel();
+        return;
+      }
     }
     // Shift+Enter inserts a soft line break (w:br inside the paragraph) —
     // captured here because the textarea reports both Enter flavors to
@@ -1391,6 +1432,12 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
       case "End":
         event.preventDefault();
         apply(edgeTarget(active().editor.state, head(), true), extend);
+        break;
+      case "Delete":
+        if (editable) {
+          event.preventDefault();
+          deleteForward(event.ctrlKey || event.metaKey);
+        }
         break;
       // Leaving a furniture story (Word: Esc = Close Header and Footer).
       case "Escape":
@@ -1508,6 +1555,15 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
       // when the plain text still matches it (stale after a copy elsewhere,
       // which is exactly when the fallback must not fire).
       if (lastCopied?.text === text && insertSlicePayload(lastCopied.payload)) return;
+      if (text.includes("\n")) {
+        const lines = text.replace(/\r\n/g, "\n").split("\n");
+        const paragraphs = lines.map((line) => ({
+          type: "paragraph",
+          content: line ? [{ type: "text", text: line }] : [],
+        }));
+        active().editor.commands.insertContent(paragraphs);
+        return;
+      }
       insertText(text);
     }
   };

--- a/packages/editor/src/document/extensions/commands.spec.ts
+++ b/packages/editor/src/document/extensions/commands.spec.ts
@@ -30,6 +30,7 @@ type AnyNode = {
   attrs: Record<string, unknown>;
   childCount: number;
   child: (i: number) => AnyNode;
+  textContent: string;
 };
 
 const tablesOf = (editor: EditorType): AnyNode[] => {
@@ -312,6 +313,40 @@ describe("table cell property commands", () => {
     expect(firstNodeOf(editor, "tableCell").attrs.textDirection).toBe("tbRl");
     expect(editor.commands["text-direction"]()).toBe(true);
     expect(firstNodeOf(editor, "tableCell").attrs.textDirection).toBeFalsy();
+  });
+
+  it("cell-shading, align-cell, and text-direction apply to all cells when CellSelection is active", () => {
+    const editor = build();
+    editor.commands["insert-table"]();
+    caretInCell(editor, 1, 0);
+    // Select entire row 1 (3 cells)
+    expect(editor.commands["select-table-row"]()).toBe(true);
+
+    // Apply shading to all selected cells
+    expect(editor.commands["cell-shading"]("FFFF00")).toBe(true);
+    const table = tablesOf(editor)[0]!;
+    const row1 = table.child(1);
+    for (let c = 0; c < row1.childCount; c += 1) {
+      expect((row1.child(c).attrs.shading as { fill: string }).fill).toBe("FFFF00");
+    }
+    // Cells in row 0 should still be unshaded
+    expect(table.child(0).child(0).attrs.shading).toBeNull();
+
+    // Apply align-cell to all selected cells
+    expect(editor.commands["align-cell"]("bc")).toBe(true);
+    const tableAfterAlign = tablesOf(editor)[0]!;
+    const row1AfterAlign = tableAfterAlign.child(1);
+    for (let c = 0; c < row1AfterAlign.childCount; c += 1) {
+      expect(row1AfterAlign.child(c).attrs.verticalAlign).toBe("bottom");
+    }
+
+    // Apply text-direction to all selected cells
+    expect(editor.commands["text-direction"]()).toBe(true);
+    const tableAfterDir = tablesOf(editor)[0]!;
+    const row1AfterDir = tableAfterDir.child(1);
+    for (let c = 0; c < row1AfterDir.childCount; c += 1) {
+      expect(row1AfterDir.child(c).attrs.textDirection).toBe("tbRl");
+    }
   });
 });
 

--- a/packages/editor/src/document/extensions/commands.ts
+++ b/packages/editor/src/document/extensions/commands.ts
@@ -439,6 +439,10 @@ export function tableAncestry(state: EditorState): {
   rowAt: number;
   cellAt: number;
 } | null {
+  if (state.selection instanceof CellSelection) {
+    const sel = state.selection as unknown as CellSelection;
+    return ancestryAt(state.doc.resolve(sel.anchorCell + 1));
+  }
   return ancestryAt(state.selection.$from);
 }
 
@@ -1305,22 +1309,34 @@ export const DocumentCommands = Extension.create({
           const anchor = tableAncestry(state);
           if (!anchor || anchor.cellAt < 0) return false;
           if (dispatch) {
-            const { $from } = state.selection;
-            const cellPos = $from.before(anchor.cellAt);
-            const cell = $from.node(anchor.cellAt);
-            const from = cellPos + 1;
-            const to = cellPos + cell.nodeSize - 1;
+            const tr = state.tr;
             const { paragraph } = state.schema.nodes;
-            const tr = state.tr.setNodeMarkup(cellPos, undefined, {
-              ...cell.attrs,
-              verticalAlign: spec.v,
-            });
-            state.doc.nodesBetween(from, to, (node, pos) => {
-              if (node.type === paragraph && node.attrs.alignment !== spec.h) {
-                tr.setNodeMarkup(pos, undefined, { ...node.attrs, alignment: spec.h });
-              }
-              return true;
-            });
+            const applyToCell = (cell: PMNode, cellPos: number) => {
+              const live = tr.doc.nodeAt(cellPos);
+              if (!live) return;
+              tr.setNodeMarkup(cellPos, undefined, {
+                ...live.attrs,
+                verticalAlign: spec.v,
+              });
+              const from = cellPos + 1;
+              const to = cellPos + live.nodeSize - 1;
+              state.doc.nodesBetween(from, to, (node, pos) => {
+                if (node.type === paragraph && node.attrs.alignment !== spec.h) {
+                  tr.setNodeMarkup(pos, undefined, { ...node.attrs, alignment: spec.h });
+                }
+                return true;
+              });
+            };
+            if (state.selection instanceof CellSelection) {
+              (state.selection as unknown as CellSelection).forEachCell((cell, cellPos) => {
+                applyToCell(cell, cellPos);
+              });
+            } else {
+              const { $from } = state.selection;
+              const cellPos = $from.before(anchor.cellAt);
+              const cell = $from.node(anchor.cellAt);
+              applyToCell(cell, cellPos);
+            }
             dispatch(tr.scrollIntoView());
           }
           return true;
@@ -1355,14 +1371,19 @@ export const DocumentCommands = Extension.create({
           const stamp = shadingStamp(value);
           if (stamp === undefined) return false;
           if (dispatch) {
-            const { $from } = state.selection;
-            const cellPos = $from.before(anchor.cellAt);
-            const cell = $from.node(anchor.cellAt);
-            dispatch(
-              state.tr
-                .setNodeMarkup(cellPos, undefined, { ...cell.attrs, shading: stamp })
-                .scrollIntoView(),
-            );
+            const tr = state.tr;
+            if (state.selection instanceof CellSelection) {
+              (state.selection as unknown as CellSelection).forEachCell((_cell, cellPos) => {
+                const live = tr.doc.nodeAt(cellPos);
+                if (live) tr.setNodeMarkup(cellPos, undefined, { ...live.attrs, shading: stamp });
+              });
+            } else {
+              const { $from } = state.selection;
+              const cellPos = $from.before(anchor.cellAt);
+              const cell = $from.node(anchor.cellAt);
+              tr.setNodeMarkup(cellPos, undefined, { ...cell.attrs, shading: stamp });
+            }
+            dispatch(tr.scrollIntoView());
           }
           return true;
         },
@@ -1452,15 +1473,23 @@ export const DocumentCommands = Extension.create({
           const anchor = tableAncestry(state);
           if (!anchor || anchor.cellAt < 0) return false;
           if (dispatch) {
-            const { $from } = state.selection;
-            const cellPos = $from.before(anchor.cellAt);
-            const cell = $from.node(anchor.cellAt);
-            const next = cell.attrs.textDirection ? null : "tbRl";
-            dispatch(
-              state.tr
-                .setNodeMarkup(cellPos, undefined, { ...cell.attrs, textDirection: next })
-                .scrollIntoView(),
-            );
+            const tr = state.tr;
+            if (state.selection instanceof CellSelection) {
+              (state.selection as unknown as CellSelection).forEachCell((_cell, cellPos) => {
+                const live = tr.doc.nodeAt(cellPos);
+                if (live) {
+                  const next = live.attrs.textDirection ? null : "tbRl";
+                  tr.setNodeMarkup(cellPos, undefined, { ...live.attrs, textDirection: next });
+                }
+              });
+            } else {
+              const { $from } = state.selection;
+              const cellPos = $from.before(anchor.cellAt);
+              const cell = $from.node(anchor.cellAt);
+              const next = cell.attrs.textDirection ? null : "tbRl";
+              tr.setNodeMarkup(cellPos, undefined, { ...cell.attrs, textDirection: next });
+            }
+            dispatch(tr.scrollIntoView());
           }
           return true;
         },

--- a/packages/editor/src/document/index.ts
+++ b/packages/editor/src/document/index.ts
@@ -305,6 +305,16 @@ class DocenDocument extends AddinHost<Editor> {
     this.#setZoom(event.detail.zoom);
   };
 
+  /** Ctrl+Wheel zoom on the canvas (Word / standard desktop behavior). */
+  readonly #onWheel = (event: WheelEvent): void => {
+    if (event.ctrlKey || event.metaKey) {
+      event.preventDefault();
+      event.stopPropagation();
+      const delta = event.deltaY < 0 ? 10 : -10;
+      this.#setZoom(this.#zoom + delta);
+    }
+  };
+
   /** Ctrl+= / Ctrl+- / Ctrl+0 zoom, Ctrl+F find (Word behavior). Zoom is
    *  ignored inside ribbon comboboxes and other inputs (so the keystroke reaches
    *  them); Ctrl+F is global. preventDefault blocks the browser's native zoom/find. */
@@ -961,6 +971,7 @@ class DocenDocument extends AddinHost<Editor> {
     this.editor?.on("selectionUpdate", this.#syncActiveCommentCard);
     document.addEventListener("fullscreenchange", this.#onFullscreenChange);
     this.addEventListener("keydown", this.#onZoomKey);
+    this.addEventListener("wheel", this.#onWheel, { capture: true, passive: false });
     this.dispatchEvent(new CustomEvent("docen:ready", { bubbles: true, composed: true }));
   }
 
@@ -1391,6 +1402,7 @@ class DocenDocument extends AddinHost<Editor> {
     this.editor?.off("selectionUpdate", this.#syncActiveCommentCard);
     document.removeEventListener("fullscreenchange", this.#onFullscreenChange);
     this.removeEventListener("keydown", this.#onZoomKey);
+    this.removeEventListener("wheel", this.#onWheel, { capture: true });
     this.shadowRoot
       ?.querySelector("docen-ribbon")
       ?.removeEventListener("ribbon-mode-change", this.#onRibbonModeChange);
@@ -2190,7 +2202,10 @@ class DocenDocument extends AddinHost<Editor> {
       }
     });
     // After the leaf atom (pos is its left edge) so the caret sits past it.
-    if (target != null) this.#setTextSelection(target + 1);
+    if (target != null) {
+      this.#setTextSelection(target + 1);
+      this.#bridge?.scrollIntoView(target + 1);
+    }
   }
 
   /** One inlinePassthrough comment atom (see #insertComment) → its marker


### PR DESCRIPTION
## Summary
This pull request addresses 6 distinct interaction friction points across list editing, node deletion, plain text paste, canvas wheel zoom, footnote scrolling, and multi-cell table formatting:

### 1. List Item Backspace Navigation (`@docen/editor`)
- **Problem**: Pressing `Backspace` at offset 0 of a list item previously called `joinBackward`, merging the list item into the preceding item and destroying paragraph boundaries (e.g. `1. FirstSecond`).
- **Fix**: Following standard Word processor behavior:
  - If the list item has `level > 0`, Backspace outdents the list level by one (`listLevelStepPatch(attrs, -1)`).
  - If the list item is at `level === 0`, Backspace removes list formatting (`bullet: null, numbering: null`), turning it back into a regular body paragraph without joining.

### 2. Deleting Selected Images & Drawings (`@docen/editor`)
- **Problem**: When a picture or shape was selected (`NodeSelection`), pressing `Delete` on an empty bridge textarea did not trigger `beforeinput` in some browsers, and the selection overlay was left behind.
- **Fix**: In `onKeyDown`, handles `sel instanceof NodeSelection` on `Backspace` and `Delete` by calling `tr.deleteSelection()` and clearing the `selDrawing` overlay. Also adds `case "Delete":` to the keydown switch to ensure reliable forward deletion.

### 3. Pasting Multiline Plain Text as Paragraphs (`@docen/editor`)
- **Problem**: Pasting multiline text (`text/plain`) passed raw string to `tr.insertText(text)`, creating a single paragraph with embedded literal `\n` characters, violating the ProseMirror schema and causing layout anomalies.
- **Fix**: Splits multiline text by `\n` into separate paragraph nodes via `insertContent(paragraphs)`.

### 4. Ctrl + Mouse Wheel Canvas Zoom (`@docen/editor`)
- **Problem**: Zoom was only available via keyboard (`Ctrl + =`, `Ctrl + -`) and the status-bar slider. Holding `Ctrl` / `Cmd` while scrolling the mouse wheel did not zoom the document.
- **Fix**: Listens for `wheel` events on `<docen-document>` in the capture phase. If `event.ctrlKey || event.metaKey`, prevents browser scroll/zoom and adjusts the document canvas zoom smoothly (`this.#setZoom(this.#zoom ± 10)`).

### 5. Next Footnote Scroll to View (`@docen/editor`)
- **Problem**: Clicking "Next Footnote" in the References ribbon moved the cursor to the next footnote reference atom, but never scrolled the canvas to display it.
- **Fix**: Calls `this.#bridge?.scrollIntoView(target + 1)` after selection update.

### 6. Multi-Cell Shading, Alignment & Text Direction (`@docen/editor`)
- **Problem**: When multiple cells or a row/column were selected via `CellSelection`, clicking *Shading*, *Align Cell*, or *Text Direction* only modified the single anchor cell and ignored all other selected cells.
- **Fix**:
  - `tableAncestry` resolves `anchorCell + 1` when `CellSelection` is active so depth indices are valid.
  - `align-cell`, `cell-shading`, and `text-direction` now check `state.selection instanceof CellSelection` and apply the transformation across all selected cells using `forEachCell`.

## Verification
- Added automated unit test in `commands.spec.ts` testing multi-cell shading, alignment, and text direction on `CellSelection`.
- All 390 monorepo unit tests pass.
- `pnpm check` passed with 0 errors.
- `pnpm build` succeeded across the monorepo.