### PR TITLE
feat: improve canvas navigation, tables, shortcuts, and context menu

### DIFF
--- a/packages/editor/src/document/canvas/caret-map.spec.ts
+++ b/packages/editor/src/document/canvas/caret-map.spec.ts
@@ -351,3 +351,26 @@ describe("CaretMap tolerant zip", () => {
     expect(map.caretRect(12)?.yPx).toBe(150);
   });
 });
+
+describe("CaretMap vertical stepping", () => {
+  it("steps within the same paragraph and across paragraph boundaries", () => {
+    const { doc } = buildDoc(["hello", "world"]);
+    const map = new CaretMap(
+      pageOf([
+        fakePara([{ text: "hello", xPx: 0, yPx: 0, maxWidthPx: 100 }]),
+        fakePara([{ text: "world", xPx: 0, yPx: 50, maxWidthPx: 100 }]),
+      ]) as never,
+      doc,
+      () => ({ contentLeftPx: 0, contentTopPx: 0 }),
+    );
+    // In doc:
+    // para 1: pos 1 ("h") to pos 6
+    // para 2: pos 8 ("w") to pos 13
+    // posVertical from pos 2 ('e') downwards: crosses to para 2 at same col ('o' -> pos 9)
+    const down = map.posVertical(2, 1);
+    expect(down).toBe(9);
+    // posVertical from pos 9 ('o') upwards: crosses back to para 1 at pos 2 ('e')
+    const up = map.posVertical(9, -1);
+    expect(up).toBe(2);
+  });
+});

--- a/packages/editor/src/document/canvas/caret-map.ts
+++ b/packages/editor/src/document/canvas/caret-map.ts
@@ -494,21 +494,27 @@ export class CaretMap {
     return this.posInLine(best.entry, x);
   }
 
-  /** The position one line above/below a position's line, at the same
-   *  character column (clamped to the target line's length — the Word goal
-   *  column; a pixel target would drift across differently stretched
-   *  justified lines). Null at the paragraph's vertical edge. */
+  /** One line up/down at the same character column (within the paragraph or
+   *  crossing into adjacent paragraphs across the document). Null at document edge. */
   posVertical(pos: number, dir: -1 | 1): number | null {
     const located = this.locate(pos);
     if (!located) return null;
     const lines = located.entry.lines;
-    const target = lines[lines.indexOf(located.line) + dir];
+    let target = lines[lines.indexOf(located.line) + dir];
+    let owner = located.entry;
+    if (!target) {
+      const allIdx = this.lines.indexOf(located.line);
+      if (allIdx >= 0) {
+        target = this.lines[allIdx + dir];
+        if (target) owner = target.owner;
+      }
+    }
     if (!target) return null;
     const col = Math.min(
       located.offset - located.line.startChar,
       target.endChar - target.startChar,
     );
-    return this.posOfChar(located.entry, target.startChar + col);
+    return this.posOfChar(owner, target.startChar + col);
   }
 
   /** The vertical caret box of a line — anchored where the painter actually

--- a/packages/editor/src/document/canvas/edit-bridge.ts
+++ b/packages/editor/src/document/canvas/edit-bridge.ts
@@ -847,7 +847,7 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     dragMoved = false;
     dragStart = null;
   };
-  opts.host.addEventListener("mousemove", onMouseMove);
+  document.addEventListener("mousemove", onMouseMove);
   document.addEventListener("mouseup", onMouseUp);
 
   /** Enter a furniture story: a second viewless editor over the slot's
@@ -1233,19 +1233,23 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     ta.value = "";
   };
 
-  /** One step horizontally from a position — a grapheme inside the block
+  /** One step horizontally from a position — a grapheme or word inside the block
    *  (atoms step a whole node), the nearest text position past its edge. */
-  const hStep = (state: Editor["state"], pos: number, dir: -1 | 1): number | null => {
+  const hStep = (state: Editor["state"], pos: number, dir: -1 | 1, word = false): number | null => {
     const $from = state.doc.resolve(pos);
     const offset = $from.parentOffset;
     const size = $from.parent.content.size;
+    const text = $from.parent.textBetween(0, size);
     if (dir < 0 && offset > 0) {
-      // textBetween maps the content offset to text units, skipping atoms.
-      const cut = lastGraphemeUnits($from.parent.textBetween(0, offset)) || 1;
+      const cut = word
+        ? wordUnitsBackward(text, offset)
+        : lastGraphemeUnits(text.slice(0, offset)) || 1;
       return pos - cut;
     }
     if (dir > 0 && offset < size) {
-      const cut = firstGraphemeUnits($from.parent.textBetween(offset, size)) || 1;
+      const cut = word
+        ? wordUnitsForward(text, offset)
+        : firstGraphemeUnits(text.slice(offset)) || 1;
       return pos + cut;
     }
     const edge = dir < 0 ? $from.before() : $from.after();
@@ -1278,6 +1282,12 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     } else {
       setSel(target);
     }
+  };
+
+  const scrollTo = (pos: number): void => {
+    const rect = active().map?.valid ? active().map!.caretRect(pos) : null;
+    if (!rect) return;
+    opts.pageHost?.(rect.page)?.scrollIntoView({ block: "start", behavior: "auto" });
   };
 
   const onKeyDown = (event: KeyboardEvent): void => {
@@ -1344,6 +1354,18 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
         );
         return;
       }
+      // Mod-K: Insert / edit hyperlink (Word standard).
+      if (lower === "k") {
+        event.preventDefault();
+        opts.host.dispatchEvent(
+          new CustomEvent("command", {
+            bubbles: true,
+            composed: true,
+            detail: { event: "link" },
+          }),
+        );
+        return;
+      }
       // Viewless editors have no EditorView, so nothing dispatches Tiptap's
       // per-extension keyboard shortcuts — match the shared table here (the
       // DocenKeymap extension serves the same table on a DOM route). Named
@@ -1370,11 +1392,19 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     switch (event.key) {
       case "ArrowLeft":
         event.preventDefault();
-        apply(hStep(active().editor.state, head(), -1), extend);
+        if (selDrawing != null) {
+          selDrawing = null;
+          placeDrawingSel();
+        }
+        apply(hStep(active().editor.state, head(), -1, event.ctrlKey || event.metaKey), extend);
         break;
       case "ArrowRight":
         event.preventDefault();
-        apply(hStep(active().editor.state, head(), 1), extend);
+        if (selDrawing != null) {
+          selDrawing = null;
+          placeDrawingSel();
+        }
+        apply(hStep(active().editor.state, head(), 1, event.ctrlKey || event.metaKey), extend);
         break;
       case "ArrowUp":
         event.preventDefault();
@@ -1384,16 +1414,64 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
         event.preventDefault();
         apply(vStep(head(), 1), extend);
         break;
-      case "Home":
+      case "Home": {
         event.preventDefault();
-        apply(edgeTarget(active().editor.state, head(), false), extend);
+        const target =
+          event.ctrlKey || event.metaKey ? 0 : edgeTarget(active().editor.state, head(), false);
+        apply(target, extend);
+        scrollTo(target);
         break;
-      case "End":
+      }
+      case "End": {
         event.preventDefault();
-        apply(edgeTarget(active().editor.state, head(), true), extend);
+        const target =
+          event.ctrlKey || event.metaKey
+            ? active().editor.state.doc.content.size
+            : edgeTarget(active().editor.state, head(), true);
+        apply(target, extend);
+        scrollTo(target);
+        break;
+      }
+      case "PageUp": {
+        event.preventDefault();
+        const map = active().map;
+        if (map?.valid) {
+          const cur = head();
+          const curPage = map.caretRect(cur)?.page ?? 0;
+          const targetPage = Math.max(0, curPage - 1);
+          const targetPos = map.firstPosOfPage(targetPage) ?? 0;
+          apply(targetPos, extend);
+          scrollTo(targetPos);
+        }
+        break;
+      }
+      case "PageDown": {
+        event.preventDefault();
+        const map = active().map;
+        if (map?.valid) {
+          const cur = head();
+          const curPage = map.caretRect(cur)?.page ?? 0;
+          const targetPos =
+            map.firstPosOfPage(curPage + 1) ?? active().editor.state.doc.content.size;
+          apply(targetPos, extend);
+          scrollTo(targetPos);
+        }
+        break;
+      }
+      case "Delete":
+        if (editable) {
+          event.preventDefault();
+          deleteForward(event.ctrlKey || event.metaKey);
+        }
         break;
       // Leaving a furniture story (Word: Esc = Close Header and Footer).
       case "Escape":
+        if (selDrawing != null) {
+          event.preventDefault();
+          selDrawing = null;
+          placeDrawingSel();
+          return;
+        }
         if (story) {
           event.preventDefault();
           leaveStory();
@@ -1666,9 +1744,7 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
       return leaveStory();
     },
     scrollIntoView(pos): void {
-      const rect = main.map?.valid ? main.map.caretRect(pos) : null;
-      if (!rect) return;
-      opts.pageHost?.(rect.page)?.scrollIntoView({ block: "start", behavior: "auto" });
+      scrollTo(pos);
     },
     /** The page index a doc position renders on (null when unmappable). */
     pageOf(pos): number | null {
@@ -1724,7 +1800,7 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
       story = null;
       main.editor.destroy();
       opts.host.removeEventListener("mousedown", takeFocus);
-      opts.host.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mousemove", onMouseMove);
       document.removeEventListener("mouseup", onMouseUp);
       drawingSel.remove();
       for (const el of selectionLayer) el.remove();

--- a/packages/editor/src/document/extensions/commands.spec.ts
+++ b/packages/editor/src/document/extensions/commands.spec.ts
@@ -3,6 +3,7 @@ import { Document, Image, Paragraph, Table, TableCell, TableRow, WpsShape } from
 import { Editor, Node as TextNode, type Editor as EditorType } from "@docen/docx/core";
 import { describe, expect, it } from "vitest";
 
+import { CellSelection } from "../canvas/cell-selection";
 import { DocumentCommands } from "./commands";
 
 // Tiptap's schema needs the plain text node (same trick as the TOC spec).
@@ -469,14 +470,38 @@ describe("merge / split table commands", () => {
     expect(tables).toHaveLength(2);
     expect(tables[0]!.childCount).toBe(1);
     expect(tables[1]!.childCount).toBe(2);
+    // The separator paragraph sits between the two tables (keeps them separate in Word).
+    expect(editor.state.doc.child(1).type.name).toBe("paragraph");
     // The caret lands in the second table's first cell.
     const $from = editor.state.doc.resolve(editor.state.selection.from);
-    // The caret sits inside the second table (the one after the split).
     expect($from.node(3).type.name).toBe("tableCell");
-    expect($from.before(1)).toBe(editor.state.doc.firstChild!.nodeSize);
+    expect($from.before(1)).toBe(
+      editor.state.doc.firstChild!.nodeSize + editor.state.doc.child(1).nodeSize,
+    );
     // Splitting at the first row declines.
     caretInCell(editor, 0, 0);
     expect(editor.commands["split-table"]()).toBe(false);
+  });
+
+  it("column-break inside a table delegates to split-table", () => {
+    const editor = build();
+    editor.commands["insert-table"]();
+    caretInCell(editor, 1, 0);
+    expect(editor.commands["column-break"]()).toBe(true);
+    expect(tablesOf(editor)).toHaveLength(2);
+  });
+
+  it("merge-cells supports CellSelection directly from canvas drag", () => {
+    const editor = build();
+    editor.commands["insert-table"]();
+    caretInCell(editor, 0, 0);
+    // Select the first row via CellSelection.
+    editor.commands["select-table-row"]();
+    expect(editor.state.selection instanceof CellSelection).toBe(true);
+    expect(editor.commands["merge-cells"]()).toBe(true);
+    const row = tablesOf(editor)[0]!.child(0);
+    expect(row.childCount).toBe(1);
+    expect(row.child(0).attrs.columnSpan).toBe(3);
   });
 });
 

--- a/packages/editor/src/document/extensions/commands.ts
+++ b/packages/editor/src/document/extensions/commands.ts
@@ -1029,8 +1029,15 @@ export const DocumentCommands = Extension.create({
           commands.setPageBreak(),
       "column-break":
         () =>
-        ({ commands }) =>
-          commands.setColumnBreak(),
+        ({ state, commands }) => {
+          const anchor = tableAncestry(state);
+          if (anchor && anchor.tableAt >= 0) {
+            return (
+              (commands as unknown as Record<string, () => boolean>)["split-table"]?.() ?? false
+            );
+          }
+          return commands.setColumnBreak();
+        },
       "section-break":
         () =>
         ({ commands }) =>
@@ -1502,22 +1509,30 @@ export const DocumentCommands = Extension.create({
       "merge-cells":
         () =>
         ({ state, dispatch }) => {
-          const fromA = ancestryAt(state.selection.$from);
-          const toA = ancestryAt(state.selection.$to);
+          let $from = state.selection.$from;
+          let $to = state.selection.$to;
+          if (state.selection instanceof CellSelection) {
+            const sel = state.selection as unknown as CellSelection;
+            const $a = state.doc.resolve(sel.anchorCell + 2);
+            const $h = state.doc.resolve(sel.headCell + 2);
+            $from = $a.pos <= $h.pos ? $a : $h;
+            $to = $a.pos <= $h.pos ? $h : $a;
+          }
+          const fromA = ancestryAt($from);
+          const toA = ancestryAt($to);
           if (!fromA || !toA || fromA.rowAt < 0 || toA.rowAt < 0) return false;
-          const { $from, $to } = state.selection;
           if ($from.before(fromA.tableAt) !== $to.before(toA.tableAt)) return false;
           const tableNode = $from.node(fromA.tableAt);
           const grid = (tableNode.attrs.columnWidths as number[] | null)?.length ?? 0;
-          const c1 = $from.index(fromA.rowAt);
-          const c2 = $to.index(toA.rowAt);
-          if (fromA.rowAt === toA.rowAt && c1 === c2) return false;
+          const c1 = Math.min($from.index(fromA.rowAt), $to.index(toA.rowAt));
+          const c2 = Math.max($from.index(fromA.rowAt), $to.index(toA.rowAt));
+          const rowFrom = Math.min($from.index(fromA.tableAt), $to.index(toA.tableAt));
+          const rowTo = Math.max($from.index(fromA.tableAt), $to.index(toA.tableAt));
+          if (rowFrom === rowTo && c1 === c2) return false;
           if (dispatch) {
             const tablePos = $from.before(fromA.tableAt);
             // Row indices into the table's children — the ancestry depths are
             // not indexes (a depth-2 rowAt would address the last row).
-            const rowFrom = $from.index(fromA.tableAt);
-            const rowTo = $to.index(toA.tableAt);
             const tr = state.tr;
             for (let r = rowTo; r >= rowFrom; r -= 1) {
               const rowNode = tableNode.child(r);
@@ -1575,7 +1590,8 @@ export const DocumentCommands = Extension.create({
           return true;
         },
       // Word's Split Table: the caret's row starts a second table with the
-      // same formatting (attrs are shared — borders, grid, style).
+      // same formatting (attrs are shared — borders, grid, style), separated
+      // by a blank paragraph so the two tables don't merge back in Word.
       "split-table":
         () =>
         ({ state, dispatch }) => {
@@ -1593,14 +1609,18 @@ export const DocumentCommands = Extension.create({
               (r < rowIdx ? rowsA : rowsB).push(tableNode.child(r));
             }
             const create = state.schema.nodes.table.create.bind(state.schema.nodes.table);
+            const sep = state.schema.nodes.paragraph.create();
             const tr = state.tr.replaceWith(tablePos, tablePos + tableNode.nodeSize, [
               create(tableNode.attrs, rowsA),
+              sep,
               create(tableNode.attrs, rowsB),
             ]);
             // The caret lands in the second table's first cell: the first
-            // table's size is its rows plus the open/close tokens.
+            // table's size is its rows plus the open/close tokens, plus the separator paragraph.
             const firstTableSize = rowsA.reduce((sum, r) => sum + r.nodeSize, 0) + 2;
-            tr.setSelection(TextSelection.near(tr.doc.resolve(tablePos + firstTableSize + 1)));
+            tr.setSelection(
+              TextSelection.near(tr.doc.resolve(tablePos + firstTableSize + sep.nodeSize + 1)),
+            );
             dispatch(tr.scrollIntoView());
           }
           return true;

--- a/packages/editor/src/document/index.ts
+++ b/packages/editor/src/document/index.ts
@@ -544,6 +544,9 @@ class DocenDocument extends AddinHost<Editor> {
     if (action === "find-next") findNext(editor.state, editor.view.dispatch);
     else if (action === "replace-next") replaceNext(editor.state, editor.view.dispatch);
     else if (action === "replace-all") replaceAll(editor.state, editor.view.dispatch);
+    if (action === "find-next" || action === "replace-next") {
+      this.#bridge?.scrollIntoView(editor.state.selection.from);
+    }
   };
 
   /** Set a text selection (or a range) on the viewless editor. Same runtime
@@ -2368,19 +2371,25 @@ class DocenDocument extends AddinHost<Editor> {
       value: "keep-text-only",
     });
     items.push({ text: "-" });
-    if (inSelection) {
-      if (onLink) {
-        items.push({ text: t("context.edit-link", this), event: "link" });
-        items.push({ text: t("context.unlink", this), event: "unset-link" });
-      } else {
-        items.push({ text: t("context.link", this), event: "link" });
-      }
+    if (onLink) {
+      items.push({ text: t("context.edit-link", this), event: "link" });
+      items.push({ text: t("context.unlink", this), event: "unset-link" });
+      items.push({ text: "-" });
+    } else if (inSelection) {
+      items.push({ text: t("context.link", this), event: "link" });
       items.push({ text: t("context.comment", this), event: "new-comment" });
       items.push({ text: "-" });
     }
     items.push({ text: t("context.select-all", this), event: "select" });
     if (inTable) {
       items.push({ text: "-" });
+      items.push({ text: t("ribbon.cmd.insert-row-above", this), event: "insert-row-above" });
+      items.push({ text: t("ribbon.cmd.insert-row-below", this), event: "insert-row-below" });
+      items.push({ text: t("ribbon.cmd.insert-column-left", this), event: "insert-column-left" });
+      items.push({ text: t("ribbon.cmd.insert-column-right", this), event: "insert-column-right" });
+      items.push({ text: "-" });
+      items.push({ text: t("ribbon.cmd.delete-row", this), event: "delete-row" });
+      items.push({ text: t("ribbon.cmd.delete-column", this), event: "delete-column" });
       items.push({ text: t("context.delete-table", this), event: "delete-table" });
     }
     menu.setAttribute("items", JSON.stringify(items));
@@ -3178,6 +3187,9 @@ class DocenDocument extends AddinHost<Editor> {
     const cmd = commands[name];
     if (typeof cmd === "function") {
       cmd(value);
+      if (name === "next-change" || name === "previous-change") {
+        this.#bridge?.scrollIntoView(target.state.selection.from);
+      }
       // The comboboxes keep focus to filter their lists — after a pick, hand
       // the keyboard back to the document (buttons never take it: their
       // mousedown preventDefaults).

--- a/packages/editor/src/ui/components/workspace/find-replace-dialog.ts
+++ b/packages/editor/src/ui/components/workspace/find-replace-dialog.ts
@@ -128,7 +128,19 @@ class DocenFindReplaceDialog extends FASTElement {
   connectedCallback(): void {
     super.connectedCallback();
     this.find?.addEventListener("input", () => this.#emit("query"));
+    this.find?.addEventListener("keydown", (event: KeyboardEvent) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        this.#emit("find-next");
+      }
+    });
     this.replace?.addEventListener("input", () => this.#emit("query"));
+    this.replace?.addEventListener("keydown", (event: KeyboardEvent) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        this.#emit("replace-next");
+      }
+    });
     const root = this.shadowRoot!;
     root
       .querySelector("[part='find-next']")


### PR DESCRIPTION
## Summary

This PR addresses and resolves a set of verified canvas navigation, keyboard shortcut, table manipulation, and context menu issues:

### 1. Canvas Navigation & Caret Stepping
- **`CaretMap.posVertical()`**: Allows vertical navigation to cross paragraph boundaries across the entire document via `this.lines` (previously trapped the cursor inside single-line paragraphs when pressing ArrowUp at start or ArrowDown at end).
- **Word-Level Stepping (`Ctrl/Cmd + ArrowLeft/Right`)**: Enhances `hStep()` to support jumping words with `wordUnitsBackward` and `wordUnitsForward`, including range selection when combined with Shift.
- **Document Boundary Jump (`Ctrl/Cmd + Home/End`)**: Navigates directly to the beginning (`0`) or end of the document (`doc.content.size`) and scrolls into view.
- **`PageUp` / `PageDown` Navigation**: Jumps one page up or down (`firstPosOfPage(page ± 1)`), preserving selection extension with Shift, and scrolling into view.
- **Selection Drag Range**: Attaches the `mousemove` listener to `document` during text selection drag so the drag does not freeze when the pointer exits the canvas host element.

### 2. Shortcuts & Drawing Interactions
- **`Mod-K`**: Dispatches the `link` command to open the hyperlink dialog (Word standard).
- **`Escape` Key**: Deselects active drawings/shapes (`selDrawing = null`) and removes the selection overlay.
- **`Delete` Key**: Correctly performs forward deletion in viewless canvas mode.

### 3. Table Splitting & Merging
- **`split-table` Separator Paragraph**: Inserts an empty paragraph between the two split tables so they remain separate in OpenXML/Word without merging back together.
- **`column-break` in Tables**: Delegates `column-break` (`Ctrl+Shift+Enter`) to `split-table` when executed inside a table (Word standard).
- **`merge-cells` on `CellSelection`**: Resolves anchor and head cell boundaries when `CellSelection` is active from a canvas drag selection.

### 4. Context Menu & Dialog Actions
- **Hyperlink Context Menu**: Displays *Edit Link...* and *Remove Hyperlink* when clicking on a link without requiring the user to manually select the entire text first.
- **Table Context Menu**: Adds table row/column operations (*Insert Row Above/Below*, *Insert Column Left/Right*, *Delete Row/Column*) to the context menu when inside a table.
- **Find & Replace Dialog**: Triggers *Find Next* / *Replace* upon pressing `Enter` in the find/replace input fields, and scrolls the canvas viewport to the found match.
- **Track Changes Navigation**: Scrolls the canvas into view when navigating via *Next Change* and *Previous Change*.

## Verification
- Added unit tests for vertical caret stepping across paragraphs in `caret-map.spec.ts`
- Added unit tests for `split-table` separator paragraph, `column-break` delegation, and `merge-cells` with `CellSelection` in `commands.spec.ts`
- All 392 tests passing (`pnpm exec vp test run`)
- `pnpm check` passed with 0 errors
- `pnpm build` succeeded