### PR TITLE
feat(editor): drawing selection frame with resize handles

### DIFF
--- a/packages/editor/src/document/canvas/drawing-editor/geometry.spec.ts
+++ b/packages/editor/src/document/canvas/drawing-editor/geometry.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { handleAt, resizeBox, type Box } from "./geometry";
+
+const box: Box = { x: 100, y: 80, width: 200, height: 100 };
+
+describe("handleAt", () => {
+  it("finds corner and edge handles on the frame", () => {
+    expect(handleAt(box, 100, 80)).toBe("nw");
+    expect(handleAt(box, 300, 180)).toBe("se");
+    expect(handleAt(box, 200, 80)).toBe("n");
+    expect(handleAt(box, 300, 130)).toBe("e");
+  });
+
+  it("returns null inside the body and outside the frame", () => {
+    expect(handleAt(box, 200, 130)).toBeNull();
+    expect(handleAt(box, 50, 50)).toBeNull();
+  });
+
+  it("prefers a corner when the pointer sits in both grab zones", () => {
+    // 3px off the NW corner is within the n, w, and nw grab zones.
+    expect(handleAt(box, 97, 77)).toBe("nw");
+  });
+});
+
+describe("resizeBox", () => {
+  it("anchors the opposite corner on a corner drag", () => {
+    const next = resizeBox(box, "se", 50, 20); // width drives, height follows
+    expect(next).toEqual({ x: 100, y: 80, width: 250, height: 125 });
+    const grown = resizeBox(box, "nw", -30, -10); // x/y move, anchor (se) fixed
+    expect(grown).toEqual({ x: 70, y: 65, width: 230, height: 115 });
+  });
+
+  it("keeps the aspect ratio on corner drags (Word's picture default)", () => {
+    const next = resizeBox(box, "se", 100, 0); // width drives
+    expect(next.width / next.height).toBeCloseTo(2);
+    expect(next.height).toBeCloseTo(150);
+  });
+
+  it("resizes one axis freely from an edge handle", () => {
+    const next = resizeBox(box, "e", 50, 999);
+    expect(next).toEqual({ x: 100, y: 80, width: 250, height: 100 });
+  });
+
+  it("clamps to the minimum instead of inverting past the anchor", () => {
+    const next = resizeBox(box, "se", -500, -500);
+    expect(next.width).toBe(24);
+    expect(next.height).toBe(24);
+    expect(next.x).toBe(100);
+    expect(next.y).toBe(80);
+  });
+
+  it("moves the anchored edge when dragging the west/north below minimum", () => {
+    const next = resizeBox(box, "nw", 500, 500);
+    expect(next.x).toBe(300 - 24);
+    expect(next.y).toBe(180 - 24);
+    expect(next.width).toBe(24);
+    expect(next.height).toBe(24);
+  });
+});

--- a/packages/editor/src/document/canvas/drawing-editor/geometry.ts
+++ b/packages/editor/src/document/canvas/drawing-editor/geometry.ts
@@ -1,0 +1,100 @@
+/**
+ * Drawing-editor geometry — the format-independent math behind the selection
+ * frame: which resize handle a pointer grabbed, and what the box becomes when
+ * that handle drags. Pure functions on plain rects; the host adapter turns the
+ * resulting box back into document attrs (docx today, pptx/xlsx tomorrow).
+ */
+
+export type HandleId = "nw" | "n" | "ne" | "e" | "se" | "s" | "sw" | "w";
+
+/** The edited drawing's box — page-local px at scale 1 (the hit box's space). */
+export interface Box {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** The eight handles, clockwise from the top-left corner. */
+export const HANDLES: readonly HandleId[] = ["nw", "n", "ne", "e", "se", "s", "sw", "w"];
+
+/** Half the grab zone beyond a handle's visual size — Word's handles are small
+ *  squares but the pointer catches a few px around them. */
+const GRAB = 6;
+
+/** The handle under a page-local point, or null when the point is on the body
+ *  (a move) or outside the frame entirely. Corner/edge handles win over the
+ *  body — a drag starting on the frame edge resizes, never moves. */
+export function handleAt(box: Box, px: number, py: number): HandleId | null {
+  const within = px >= box.x - GRAB && px <= box.x + box.width + GRAB;
+  const vertical = py >= box.y - GRAB && py <= box.y + box.height + GRAB;
+  if (!within || !vertical) return null;
+  const nearW = Math.abs(px - box.x) <= GRAB;
+  const nearE = Math.abs(px - (box.x + box.width)) <= GRAB;
+  const nearN = Math.abs(py - box.y) <= GRAB;
+  const nearS = Math.abs(py - (box.y + box.height)) <= GRAB;
+  if (nearN && nearW) return "nw";
+  if (nearN && nearE) return "ne";
+  if (nearS && nearW) return "sw";
+  if (nearS && nearE) return "se";
+  if (nearN) return "n";
+  if (nearS) return "s";
+  if (nearW) return "w";
+  if (nearE) return "e";
+  return null;
+}
+
+/** Floor to a whole px, never below 1 — a drag through zero must not flip the
+ *  box or hand the painter a 0-size node. */
+const positive = (n: number): number => Math.max(1, Math.round(n));
+
+/** The box after dragging `handle` by (dx, dy). The opposite edge/corner stays
+ *  anchored (Word: dragging a handle keeps the rest of the frame put). Corner
+ *  drags keep the aspect ratio (Word's default for pictures); edges resize one
+ *  axis freely. */
+export function resizeBox(box: Box, handle: HandleId, dx: number, dy: number, min = 24): Box {
+  const west = handle.includes("w");
+  const east = handle.includes("e");
+  const north = handle.includes("n");
+  const south = handle.includes("s");
+  const corner = west !== east && north !== south;
+
+  let { x, y, width, height } = box;
+  if (west) {
+    width = box.width - dx;
+    x = box.x + dx;
+  } else if (east) {
+    width = box.width + dx;
+  }
+  if (north) {
+    height = box.height - dy;
+    y = box.y + dy;
+  } else if (south) {
+    height = box.height + dy;
+  }
+
+  if (corner) {
+    // Aspect-locked: the larger axis drag drives, the other follows. The
+    // anchor (opposite corner) stays where it started.
+    const ratio = box.height / box.width;
+    if (width / box.width >= height / box.height) {
+      height = width * ratio;
+    } else {
+      width = height / ratio;
+    }
+    if (west) x = box.x + box.width - width;
+    if (north) y = box.y + box.height - height;
+  }
+
+  // Below the minimum, clamp the moving edge to the minimum size instead of
+  // letting the drag invert the box past its anchor.
+  if (width < min) {
+    if (west) x = box.x + box.width - min;
+    width = min;
+  }
+  if (height < min) {
+    if (north) y = box.y + box.height - min;
+    height = min;
+  }
+  return { x: positive(x), y: positive(y), width: positive(width), height: positive(height) };
+}

--- a/packages/editor/src/document/canvas/drawing-editor/overlay.ts
+++ b/packages/editor/src/document/canvas/drawing-editor/overlay.ts
@@ -1,0 +1,158 @@
+import { HANDLES, resizeBox, type Box, type HandleId } from "./geometry";
+
+/**
+ * The drawing selection frame — Word's picture selection: a border plus eight
+ * resize handles, with the pointer gestures that drag them. Format-independent:
+ * it works on a plain box and reports the resized box through {@link
+ * DrawingOverlayCallbacks}; the host adapter owns what a box change means.
+ *
+ * The overlay is a DOM layer over the canvas (like the caret/selection
+ * overlays) — synthetic pointer events reach it directly, where Leafer's
+ * scene graph would swallow them.
+ */
+
+/** Host-provided I/O: read the scale (page px → screen px), and apply a box
+ *  the user dragged to. `applyBox` returns false to reject (e.g. a read-only
+ *  doc) — the frame snaps back on the next show/refresh. */
+export interface DrawingOverlayCallbacks {
+  scale(): number;
+  applyBox(box: Box): void;
+}
+
+export class DrawingOverlay {
+  readonly el: HTMLDivElement;
+  #callbacks: DrawingOverlayCallbacks;
+  #box: Box | null = null;
+  #drag: { handle: HandleId; startX: number; startY: number; origin: Box } | null = null;
+  #handles = new Map<HandleId, HTMLDivElement>();
+
+  constructor(callbacks: DrawingOverlayCallbacks) {
+    this.#callbacks = callbacks;
+    this.el = document.createElement("div");
+    // The bridge's takeFocus treats any click inside a `data-docen-overlay`
+    // widget as the widget's own — a handle grab must not drop a caret.
+    this.el.setAttribute("data-docen-overlay", "");
+    Object.assign(this.el.style, {
+      position: "absolute",
+      pointerEvents: "none",
+      zIndex: "6",
+      display: "none",
+    } satisfies Partial<CSSStyleDeclaration>);
+    const frame = document.createElement("div");
+    Object.assign(frame.style, {
+      position: "absolute",
+      inset: "0",
+      border: "1.5px solid #2b7cd3",
+    } satisfies Partial<CSSStyleDeclaration>);
+    this.el.append(frame);
+    for (const id of HANDLES) {
+      const h = document.createElement("div");
+      h.dataset.handle = id;
+      Object.assign(h.style, {
+        position: "absolute",
+        width: "8px",
+        height: "8px",
+        boxSizing: "border-box",
+        background: "#fff",
+        border: "1.5px solid #2b7cd3",
+        pointerEvents: "auto",
+        cursor: HANDLE_CURSORS[id],
+      } satisfies Partial<CSSStyleDeclaration>);
+      // Word's corner handles sit ON the frame corners; edges on their midpoints.
+      const at = HANDLE_ANCHORS[id];
+      h.style.left = at.x;
+      h.style.top = at.y;
+      this.#handles.set(id, h);
+      this.el.append(h);
+      h.addEventListener("pointerdown", (e) => this.#onHandleDown(id, e));
+    }
+    this.el.addEventListener("pointermove", (e) => this.#onPointerMove(e));
+    for (const kind of ["pointerup", "pointercancel"] as const)
+      this.el.addEventListener(kind, () => this.#onDragEnd());
+  }
+
+  /** Show the frame over `box` (page-local px at scale 1). */
+  show(box: Box): void {
+    this.#box = box;
+    this.el.style.display = "block";
+    this.#place();
+  }
+
+  /** Refresh after the box changed underneath (a re-render, an applied drag). */
+  refresh(box: Box | null): void {
+    if (!box) return this.hide();
+    this.show(box);
+  }
+
+  hide(): void {
+    this.#box = null;
+    this.#drag = null;
+    this.el.style.display = "none";
+  }
+
+  #place(): void {
+    const box = this.#box;
+    if (!box) return;
+    const scale = this.#callbacks.scale();
+    this.el.style.left = `${box.x * scale}px`;
+    this.el.style.top = `${box.y * scale}px`;
+    this.el.style.width = `${box.width * scale}px`;
+    this.el.style.height = `${box.height * scale}px`;
+  }
+
+  #onHandleDown(handle: HandleId, event: PointerEvent): void {
+    if (!this.#box) return;
+    event.preventDefault();
+    event.stopPropagation();
+    // Capture the pointer on the handle so the drag keeps receiving moves
+    // after the cursor leaves the handle (and the frame) — without it a
+    // corner drag past the frame edge stalls the resize mid-gesture.
+    (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+    this.#drag = {
+      handle,
+      startX: event.clientX,
+      startY: event.clientY,
+      origin: { ...this.#box },
+    };
+  }
+
+  #onPointerMove(event: PointerEvent): void {
+    const drag = this.#drag;
+    if (!drag) return;
+    const scale = this.#callbacks.scale();
+    const dx = (event.clientX - drag.startX) / scale;
+    const dy = (event.clientY - drag.startY) / scale;
+    const next = resizeBox(drag.origin, drag.handle, dx, dy);
+    this.#box = next;
+    this.#place();
+  }
+
+  #onDragEnd(): void {
+    const drag = this.#drag;
+    if (!drag || !this.#box) return;
+    this.#drag = null;
+    this.#callbacks.applyBox(this.#box);
+  }
+}
+
+const HANDLE_CURSORS: Record<HandleId, string> = {
+  nw: "nwse-resize",
+  se: "nwse-resize",
+  ne: "nesw-resize",
+  sw: "nesw-resize",
+  n: "ns-resize",
+  s: "ns-resize",
+  e: "ew-resize",
+  w: "ew-resize",
+};
+
+const HANDLE_ANCHORS: Record<HandleId, { x: string; y: string }> = {
+  nw: { x: "-4px", y: "-4px" },
+  n: { x: "calc(50% - 4px)", y: "-4px" },
+  ne: { x: "calc(100% - 4px)", y: "-4px" },
+  e: { x: "calc(100% - 4px)", y: "calc(50% - 4px)" },
+  se: { x: "calc(100% - 4px)", y: "calc(100% - 4px)" },
+  s: { x: "calc(50% - 4px)", y: "calc(100% - 4px)" },
+  sw: { x: "-4px", y: "calc(100% - 4px)" },
+  w: { x: "-4px", y: "calc(50% - 4px)" },
+};

--- a/packages/editor/src/document/canvas/edit-bridge.ts
+++ b/packages/editor/src/document/canvas/edit-bridge.ts
@@ -36,6 +36,7 @@ import { listLevelStepPatch } from "../extensions/commands";
 import { KEYBOARD_SHORTCUTS } from "../extensions/keymap";
 import { CaretMap, type TableZone } from "./caret-map";
 import { CellSelection, cellAt, inSameTable } from "./cell-selection";
+import { DrawingOverlay } from "./drawing-editor/overlay";
 import { followLink, installLinkHover, type LinkHit } from "./link-hover";
 
 /** A grapheme-boundary segmenter shared by the delete translations — surrogate
@@ -695,15 +696,35 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
    *  drawing that no longer paints drops the selection. */
   let selDrawing: DrawingHit | null = null;
 
-  const drawingSel = document.createElement("div");
-  Object.assign(drawingSel.style, {
-    position: "absolute",
-    border: "1.5px solid #2b7cd3",
-    pointerEvents: "none",
-    zIndex: "6",
-    display: "none",
-  } satisfies Partial<CSSStyleDeclaration>);
-  opts.host.append(drawingSel);
+  /** The drawing-editor adapter: what a dragged box means. The box is
+   *  page-local px at scale 1; the PM node's width/height attrs are px too,
+   *  so the write-back is a direct setNodeMarkup (inline pictures size
+   *  through the same attrs; a re-render re-anchors the frame via
+   *  drawingBoxOf). */
+  const drawingOverlay = new DrawingOverlay({
+    scale: () => opts.scale?.() ?? 1,
+    applyBox: (box) => {
+      if (!selDrawing) return;
+      const nodePos = opts.drawingSelection?.(selDrawing) ?? null;
+      if (nodePos == null) return;
+      const editor = main.editor;
+      if (!editor.state.doc.nodeAt(nodePos)) return;
+      editor.commands.command(({ tr, dispatch }) => {
+        // A setNodeMarkup that changes attrs demotes a NodeSelection to a
+        // caret (PM maps the selection across the node's replace step);
+        // re-create it so the resize keeps the drawing selected — Word's
+        // picture stays selected after a handle drag.
+        tr.setNodeMarkup(nodePos, undefined, {
+          ...editor.state.doc.nodeAt(nodePos)!.attrs,
+          width: box.width,
+          height: box.height,
+        }).setSelection(NodeSelection.create(tr.doc, nodePos) as never);
+        dispatch?.(tr as never);
+        return true;
+      });
+    },
+  });
+  opts.host.append(drawingOverlay.el);
 
   const placeDrawingSel = (): void => {
     if (selDrawing) {
@@ -712,16 +733,11 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     }
     const frame = selDrawing ? (opts.pageHost?.(selDrawing.page) ?? null) : null;
     if (!selDrawing || !frame) {
-      drawingSel.style.display = "none";
+      drawingOverlay.hide();
       return;
     }
-    if (frame !== drawingSel.parentElement) frame.append(drawingSel);
-    drawingSel.style.display = "block";
-    const scale = opts.scale?.() ?? 1;
-    drawingSel.style.left = `${selDrawing.x * scale}px`;
-    drawingSel.style.top = `${selDrawing.y * scale}px`;
-    drawingSel.style.width = `${selDrawing.width * scale}px`;
-    drawingSel.style.height = `${selDrawing.height * scale}px`;
+    if (frame !== drawingOverlay.el.parentElement) frame.append(drawingOverlay.el);
+    drawingOverlay.refresh(selDrawing);
   };
 
   const selectDrawing = (hit: DrawingHit): void => {
@@ -2147,7 +2163,8 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
       opts.host.removeEventListener("mousedown", takeFocus);
       document.removeEventListener("mousemove", onMouseMove);
       document.removeEventListener("mouseup", onMouseUp);
-      drawingSel.remove();
+      drawingOverlay.hide();
+      drawingOverlay.el.remove();
       for (const el of selectionLayer) el.remove();
       for (const el of searchLayer) el.remove();
       for (const el of spellingLayer) el.remove();

--- a/packages/editor/src/document/canvas/stage.ts
+++ b/packages/editor/src/document/canvas/stage.ts
@@ -1125,6 +1125,13 @@ export class CanvasStage {
     return null;
   }
 
+  /** Every page's drawing boxes — the host's stale-hit fallback scans these
+   *  against the PM selection (the reference-identity match above cannot
+   *  survive a re-layout, which re-objects every paragraph). */
+  drawingBoxes(): DrawingHitBox[] {
+    return [...this.hitBoxes.values()].flat();
+  }
+
   /** Both furniture stacks for a page's slot, at their page positions —
    *  distances come from the page's own section. The paint context clears
    *  the body flow's grid pitch: the header/footer story keeps natural line

--- a/packages/editor/src/document/index.ts
+++ b/packages/editor/src/document/index.ts
@@ -41,7 +41,7 @@ import {
 } from "@docen/layout";
 import { attr, customElement } from "@microsoft/fast-element";
 import type { Mark } from "@tiptap/pm/model";
-import { EditorState, TextSelection, type Transaction } from "@tiptap/pm/state";
+import { EditorState, NodeSelection, TextSelection, type Transaction } from "@tiptap/pm/state";
 
 import {
   AddinHost,
@@ -721,7 +721,22 @@ class DocenDocument extends AddinHost<Editor> {
       // same order the paragraph's content carries the nodes).
       drawingAt: (page, lx, ly) => this.#stage?.drawingAt(page, lx, ly) ?? null,
       drawingSelection: (hit) => this.#drawingNodePos(hit.para, hit.index, hit.kind),
-      drawingBoxOf: (para, index, kind) => this.#stage?.drawingBoxOf(para, index, kind) ?? null,
+      drawingBoxOf: (para, index, kind) => {
+        const stage = this.#stage;
+        const hit = stage?.drawingBoxOf(para, index, kind) ?? null;
+        if (hit || !stage) return hit;
+        // A write-back (a resize) re-laid the doc and re-objected every
+        // paragraph — the caller's hit reference is stale. Re-resolve the
+        // PM selection (still a NodeSelection on the same drawing) against
+        // the fresh boxes so the frame follows the resized picture.
+        const sel = this.editor?.state.selection;
+        if (!(sel instanceof NodeSelection)) return null;
+        return (
+          stage
+            .drawingBoxes()
+            .find((box) => this.#drawingNodePos(box.para, box.index, box.kind) === sel.from) ?? null
+        );
+      },
       // `#name` links are bookmark anchors — the host owns the in-page jump.
       onInternalAnchor: (name) => this.#jumpToBookmark(name),
     });


### PR DESCRIPTION
## What

Opens the **drawing-editor layer** (`document/canvas/drawing-editor/`) — the format-independent core that picture/shape editing for docx/pptx/xlsx will build on. First batch: Word's picture selection frame with eight resize handles, wired for docx images.

- `geometry.ts` — pure functions: handle hit-testing (corners win over edges, a few px of grab zone) and anchored resize (opposite edge/corner stays put; corner drags keep the aspect ratio, Word's picture default; edges resize one axis; a minimum clamps instead of inverting past the anchor). Covered by unit specs.
- `overlay.ts` — a DOM layer over the canvas (synthetic pointer events reach it, where the Leafer scene graph would swallow them): 1.5px frame + eight 8px handles with directional cursors, pointer capture so a drag keeps tracking past the frame edge.
- `edit-bridge.ts` — the adapter: what a dragged box *means*. The box is page-local px; the image node's `width`/`height` attrs are px too, so the write-back is a direct `setNodeMarkup` and the re-render repaints the resized picture.

## Selection invariants

Two details make the gesture Word-faithful:

1. **The resize keeps the drawing selected.** A `setNodeMarkup` that changes attrs demotes a NodeSelection to a caret (PM maps the selection across the node's replace step) — the transaction re-creates the NodeSelection, so nothing about the drag ends in a cleared selection.
2. **The frame follows the resized picture.** A write-back re-lays the doc and re-objects every paragraph; the overlay's reference-identity lookup can't survive that. `drawingBoxOf` falls back to scanning the fresh hit table against the PM selection (still a NodeSelection on the same drawing) and the frame re-anchors on the new geometry — including the centered paragraph re-flow (the frame slides as the picture grows).

The handle mousedown rides the existing `data-docen-overlay` exemption, so grabbing a handle never drops a caret into the text behind it.

## Verification

- `vp check` clean, 128 tests green (6 new geometry specs).
- Demo, real pointer chain: click picture → frame + 8 handles; SE-handle drag (60, 60) → attrs 166×150 → 232×210 (aspect-locked, anchor fixed), frame tracks the re-flowed picture; Ctrl+Z restores 166×150 with the picture still selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)