### PR TITLE
feat(editor): drag a selected floating drawing to move it

### DIFF
--- a/packages/editor/demo/main.ts
+++ b/packages/editor/demo/main.ts
@@ -216,6 +216,31 @@ const demoDocument = (): JSONContent => ({
         },
       ],
     },
+    // A floating picture (wrap none, EMU offsets) — the drag-to-move and
+    // resize overlay target. The image node is inline-only, so the drawing
+    // rides its anchor paragraph's content (Word: a floating drawing lives
+    // in a run of the paragraph it anchors to). Offsets are EMU
+    // (914400/inch): 4572000 = 1.2" from the margin, 952500 = 0.26" below
+    // the anchor paragraph.
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "image",
+          attrs: {
+            src: cat.src,
+            width: 140,
+            height: 93,
+            alt: "A floating cat",
+            floating: {
+              horizontalPosition: { relative: "margin", offset: 4572000 },
+              verticalPosition: { relative: "paragraph", offset: 95250 },
+              wrap: { type: "none" },
+            },
+          },
+        },
+      ],
+    },
     // Section break — an explicit next-page section break; the next section
     // starts on a fresh page.
     {

--- a/packages/editor/src/document/canvas/drawing-editor/overlay.ts
+++ b/packages/editor/src/document/canvas/drawing-editor/overlay.ts
@@ -13,10 +13,13 @@ import { HANDLES, resizeBox, type Box, type HandleId } from "./geometry";
 
 /** Host-provided I/O: read the scale (page px → screen px), and apply a box
  *  the user dragged to. `applyBox` returns false to reject (e.g. a read-only
- *  doc) — the frame snaps back on the next show/refresh. */
+ *  doc) — the frame snaps back on the next show/refresh. `applyOffset` moves
+ *  the drawing by a drag delta (a floating drawing's move); absent, the
+ *  frame stays put on a body drag. */
 export interface DrawingOverlayCallbacks {
   scale(): number;
   applyBox(box: Box): void;
+  applyOffset?(dx: number, dy: number): void;
 }
 
 export class DrawingOverlay {
@@ -133,7 +136,51 @@ export class DrawingOverlay {
     this.#drag = null;
     this.#callbacks.applyBox(this.#box);
   }
+
+  /** True while a frame is shown (a selected drawing on screen). */
+  get active(): boolean {
+    return this.#box != null;
+  }
+
+  /** Begin a move drag from a pointerdown on the selected drawing itself
+   *  (the bridge owns that hit chain). The frame trails the pointer via
+   *  document-level listeners — the gesture starts on the canvas, not this
+   *  element — and a release past {@link MOVE_THRESHOLD} commits as an
+   *  offset; a plain click (no real move) leaves everything untouched, so
+   *  clicking the selection keeps it (Word). */
+  beginMove(clientX: number, clientY: number): void {
+    if (!this.#box) return;
+    const startX = clientX;
+    const startY = clientY;
+    const origin = { ...this.#box };
+    let moved = false;
+    let last: Box = origin;
+    const scale = (): number => this.#callbacks.scale() || 1;
+    const onMove = (event: PointerEvent): void => {
+      const dx = (event.clientX - startX) / scale();
+      const dy = (event.clientY - startY) / scale();
+      if (!moved && Math.hypot(event.clientX - startX, event.clientY - startY) < MOVE_THRESHOLD)
+        return;
+      moved = true;
+      last = { ...origin, x: origin.x + dx, y: origin.y + dy };
+      this.#box = last;
+      this.#place();
+    };
+    const onUp = (): void => {
+      document.removeEventListener("pointermove", onMove);
+      document.removeEventListener("pointerup", onUp);
+      document.removeEventListener("pointercancel", onUp);
+      if (moved) this.#callbacks.applyOffset?.(last.x - origin.x, last.y - origin.y);
+    };
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", onUp);
+    document.addEventListener("pointercancel", onUp);
+  }
 }
+
+/** Pointer travel (screen px) that separates a move drag from a plain click
+ *  on the selection. */
+const MOVE_THRESHOLD = 3;
 
 const HANDLE_CURSORS: Record<HandleId, string> = {
   nw: "nwse-resize",

--- a/packages/editor/src/document/canvas/edit-bridge.ts
+++ b/packages/editor/src/document/canvas/edit-bridge.ts
@@ -18,7 +18,7 @@ import {
   type JSONContent,
 } from "@docen/docx";
 import { Editor } from "@docen/docx/core";
-import type { FlowPage } from "@docen/layout";
+import { EMU_PER_PX, type FlowPage } from "@docen/layout";
 import { UndoRedo } from "@tiptap/extensions";
 import {
   joinBackward,
@@ -700,7 +700,9 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
    *  page-local px at scale 1; the PM node's width/height attrs are px too,
    *  so the write-back is a direct setNodeMarkup (inline pictures size
    *  through the same attrs; a re-render re-anchors the frame via
-   *  drawingBoxOf). */
+   *  drawingBoxOf). A body drag moves the drawing: the px delta converts to
+   *  EMU (the floating attrs' unit) and lands through the engine's
+   *  move-drawing command, which adds it to the current offsets. */
   const drawingOverlay = new DrawingOverlay({
     scale: () => opts.scale?.() ?? 1,
     applyBox: (box) => {
@@ -722,6 +724,14 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
         dispatch?.(tr as never);
         return true;
       });
+    },
+    applyOffset: (dx, dy) => {
+      if (!selDrawing) return;
+      const nodePos = opts.drawingSelection?.(selDrawing) ?? null;
+      if (nodePos == null) return;
+      main.editor.commands["move-drawing"](
+        JSON.stringify({ h: Math.round(dx * EMU_PER_PX), v: Math.round(dy * EMU_PER_PX) }),
+      );
     },
   });
   opts.host.append(drawingOverlay.el);
@@ -756,6 +766,26 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
    *  nearest line regardless of distance — a drag overshooting past the
    *  last line's band must keep extending to the line's end (Word), not
    *  stall the selection mid-line. */
+  /** Whether the selection is a floating drawing both axes anchor by EMU
+   *  offset — the only anchoring a pointer drag can express. Align-anchored
+   *  (and inline) drawings decline: their position isn't an offset. */
+  const movableFloating = (): boolean => {
+    const sel = main.editor.state.selection;
+    if (!(sel instanceof NodeSelection)) return false;
+    const attrs = sel.node.attrs as Record<string, unknown>;
+    const floating =
+      sel.node.type.name === "image"
+        ? (attrs.floating as Record<string, unknown> | null)
+        : ((attrs.wpsShape as Record<string, unknown> | null | undefined)?.floating as Record<
+            string,
+            unknown
+          > | null);
+    if (!floating) return false;
+    const h = floating.horizontalPosition as Record<string, unknown> | undefined;
+    const v = floating.verticalPosition as Record<string, unknown> | undefined;
+    return typeof h?.offset === "number" && typeof v?.offset === "number";
+  };
+
   const posAtClient = (clientX: number, clientY: number, clamp = false): number | null => {
     const s = active();
     const hit = hitPage(clientX, clientY);
@@ -1240,6 +1270,23 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     // any other click drops a standing drawing selection first.
     const drawHit = hit && opts.drawingAt ? opts.drawingAt(hit.page, hit.lx, hit.ly) : null;
     if (drawHit) {
+      // Word: a press on the already-selected offset-anchored floating
+      // drawing starts a move drag (the frame trails the pointer, release
+      // writes the new offsets); the drawing itself stays put until the
+      // drag commits. Any other press (another drawing, an align-anchored
+      // float, or the same one after a re-layout cleared the frame) just
+      // selects.
+      const same =
+        selDrawing &&
+        drawHit.para === selDrawing.para &&
+        drawHit.index === selDrawing.index &&
+        drawHit.kind === selDrawing.kind;
+      if (same && drawingOverlay.active && movableFloating()) {
+        drawingOverlay.beginMove(event.clientX, event.clientY);
+        ta.focus();
+        ta.value = "";
+        return;
+      }
       selectDrawing(drawHit);
       ta.focus();
       ta.value = "";

--- a/packages/editor/src/document/extensions/commands.spec.ts
+++ b/packages/editor/src/document/extensions/commands.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { Document, Image, Paragraph, Table, TableCell, TableRow, WpsShape } from "@docen/docx";
 import { Editor, Node as TextNode, type Editor as EditorType } from "@docen/docx/core";
+import { NodeSelection } from "@tiptap/pm/state";
 import { describe, expect, it } from "vitest";
 
 import { CellSelection } from "../canvas/cell-selection";
@@ -9,21 +10,24 @@ import { DocumentCommands } from "./commands";
 // Tiptap's schema needs the plain text node (same trick as the TOC spec).
 const Text = TextNode.create({ name: "text", group: "inline" });
 
+/** The schema the document commands touch. */
+const EXTENSIONS = [
+  Document,
+  Paragraph,
+  Text,
+  Table,
+  TableRow,
+  TableCell,
+  Image,
+  WpsShape,
+  DocumentCommands,
+];
+
 /** A headless editor with exactly the schema the table commands touch. */
 const build = (): EditorType =>
   new Editor({
     element: null,
-    extensions: [
-      Document,
-      Paragraph,
-      Text,
-      Table,
-      TableRow,
-      TableCell,
-      Image,
-      WpsShape,
-      DocumentCommands,
-    ],
+    extensions: EXTENSIONS,
     content: { type: "doc", content: [{ type: "paragraph" }] },
   });
 
@@ -788,5 +792,113 @@ describe("add-text — TOC level stamps", () => {
     expect(editor.commands["add-text"]("none")).toBe(true);
     expect(headingsOf()[0].heading).toBeNull();
     expect(editor.commands["add-text"]("bogus")).toBe(false);
+  });
+});
+
+describe("move-drawing", () => {
+  /** An offset-anchored floating picture in its own paragraph (Word's anchor
+   *  run shape — the image node is inline-only). */
+  const buildWithFloat = (floating: object): EditorType =>
+    new Editor({
+      element: null,
+      extensions: EXTENSIONS,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "image",
+                attrs: { src: "data:,", width: 10, height: 10, floating },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+  const selectFloat = (editor: EditorType): void => {
+    let pos = -1;
+    editor.state.doc.descendants((node, nodePos) => {
+      if (node.type.name === "image" && pos < 0) {
+        pos = nodePos;
+        return false;
+      }
+      return true;
+    });
+    editor.commands.setNodeSelection(pos);
+  };
+
+  const floatOf = (editor: EditorType): Record<string, unknown> => {
+    let floating: unknown;
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === "image" && floating === undefined) {
+        floating = (node.attrs as Record<string, unknown>).floating;
+        return false;
+      }
+      return true;
+    });
+    return floating as Record<string, unknown>;
+  };
+
+  it("adds the drag delta (EMU) to the selected drawing's offsets", () => {
+    const editor = buildWithFloat({
+      horizontalPosition: { relative: "margin", offset: 1000 },
+      verticalPosition: { relative: "paragraph", offset: 2000 },
+    });
+    selectFloat(editor);
+    expect(editor.commands["move-drawing"](JSON.stringify({ h: 300, v: -500 }))).toBe(true);
+    const floating = floatOf(editor);
+    expect((floating.horizontalPosition as Record<string, unknown>).offset).toBe(1300);
+    expect((floating.verticalPosition as Record<string, unknown>).offset).toBe(1500);
+    // The drag keeps the drawing selected (Word's picture stays grabbed).
+    expect(editor.state.selection instanceof NodeSelection).toBe(true);
+  });
+
+  it("declines with no drawing selected", () => {
+    const editor = buildWithFloat({
+      horizontalPosition: { relative: "margin", offset: 1000 },
+      verticalPosition: { relative: "paragraph", offset: 2000 },
+    });
+    editor.commands.setTextSelection(1);
+    expect(editor.commands["move-drawing"](JSON.stringify({ h: 1, v: 1 }))).toBe(false);
+  });
+
+  it("declines an inline (non-floating) picture selection", () => {
+    const editor = new Editor({
+      element: null,
+      extensions: EXTENSIONS,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "image", attrs: { src: "data:,", width: 10, height: 10 } }],
+          },
+        ],
+      },
+    });
+    selectFloat(editor);
+    expect(editor.commands["move-drawing"](JSON.stringify({ h: 1, v: 1 }))).toBe(false);
+  });
+
+  it("declines an align-anchored float — its position is not an offset", () => {
+    const editor = buildWithFloat({
+      horizontalPosition: { relative: "margin", align: "right" },
+      verticalPosition: { relative: "paragraph", offset: 2000 },
+    });
+    selectFloat(editor);
+    expect(editor.commands["move-drawing"](JSON.stringify({ h: 1, v: 1 }))).toBe(false);
+  });
+
+  it("declines malformed JSON", () => {
+    const editor = buildWithFloat({
+      horizontalPosition: { relative: "margin", offset: 1000 },
+      verticalPosition: { relative: "paragraph", offset: 2000 },
+    });
+    selectFloat(editor);
+    expect(editor.commands["move-drawing"]("not json")).toBe(false);
+    expect(editor.commands["move-drawing"]()).toBe(false);
   });
 });

--- a/packages/editor/src/document/extensions/commands.ts
+++ b/packages/editor/src/document/extensions/commands.ts
@@ -123,6 +123,7 @@ declare module "@tiptap/core" {
       // Picture — names align to Office.js InlinePicture (delete / left / top).
       "delete-picture": () => ReturnType;
       "position-picture": (value?: string) => ReturnType;
+      "move-drawing": (value?: string) => ReturnType;
       // Arrange — floating drawings (z-order, wrap, rotation, position).
       "bring-forward": () => ReturnType;
       "send-backward": () => ReturnType;
@@ -211,6 +212,7 @@ export const WIRED_DISPATCH: ReadonlySet<string> = new Set([
   "multilevel-list",
   "delete-picture",
   "position-picture",
+  "move-drawing",
   "bring-forward",
   "send-backward",
   "wrap",
@@ -2408,6 +2410,35 @@ export const DocumentCommands = Extension.create({
           // looking at the image and a scroll jump would feel jumpy.
           tr.setMeta("scrollIntoView", false);
           return true;
+        },
+      // Move a selected floating drawing (image or wps shape) by a pointer-
+      // drag delta: value is JSON {h, v} in EMU, added to the drawing's
+      // current offsets. Align-anchored floats decline — the bridge only
+      // starts a drag when both axes anchor by offset (Word converts an
+      // alignment to an offset on drag; that needs the painted position,
+      // a later batch).
+      "move-drawing":
+        (value?) =>
+        ({ state, tr }) => {
+          if (!value) return false;
+          const target = floatingDrawingAt(state);
+          if (!target) return false;
+          let parsed: { h?: number; v?: number };
+          try {
+            parsed = JSON.parse(value) as { h?: number; v?: number };
+          } catch {
+            return false;
+          }
+          const floating = floatingOf(target);
+          const h = floating.horizontalPosition as Record<string, unknown> | undefined;
+          const v = floating.verticalPosition as Record<string, unknown> | undefined;
+          if (!h || !v || typeof h.offset !== "number" || typeof v.offset !== "number")
+            return false;
+          return stampFloating(tr, target, {
+            ...floating,
+            horizontalPosition: { ...h, offset: h.offset + (parsed.h ?? 0) },
+            verticalPosition: { ...v, offset: v.offset + (parsed.v ?? 0) },
+          });
         },
       // ── Arrange — floating drawings (the Layout tab's Arrange group) ──
       // Every command targets the selected floating drawing (a floating


### PR DESCRIPTION
Batch 2 of the unified drawing editor (#1101 chain): pressing the already-selected floating drawing starts a move gesture - the selection frame trails the pointer via document-level listeners, and release past the 3px click threshold commits the px delta as EMU offsets through the new move-drawing command.

- Overlay gains beginMove + an optional applyOffset callback; a plain click (no real move) keeps the selection, Word-style
- move-drawing adds {h, v} EMU to the current offsets and keeps the NodeSelection; align-anchored floats and inline pictures decline
- Demo: the floating cat now rides its anchor paragraph's content (the image node is inline-only - a doc-level image was an invalid PM document)

Verified end to end in the demo: click selects (frame + 8 handles), drag trails, offsets write back exactly (4572000+40px*9525=4953000), selection survives the re-layout, Ctrl+Z restores.