### PR TITLE
feat(editor): rotate a selected drawing with a handle

### DIFF
--- a/packages/core/src/paint/context.ts
+++ b/packages/core/src/paint/context.ts
@@ -25,6 +25,9 @@ export interface DrawingHitBox {
    *  that sequence); "inline" — a picture line item (index counts the
    *  paragraph's inline pictures). The PM side re-finds the node per kind. */
   kind: "drawing" | "inline";
+  /** Clockwise rotation of the box about its center, degrees — the click's
+   *  hit test un-rotates the point into the box's own space. */
+  rotation?: number;
 }
 
 /** One line-number label on this page — content-flow yPx (the painter adds

--- a/packages/core/src/paint/drawing.ts
+++ b/packages/core/src/paint/drawing.ts
@@ -165,23 +165,42 @@ export function paintDrawing(
     para: host.para,
     index: host.index,
     kind: "drawing",
+    ...(drawing.rotation ? { rotation: drawing.rotation } : {}),
   });
+  // The members' target and origin: the page tree at the box origin — or, on
+  // a rotated drawing, a group parked at the box CENTER carrying the angle
+  // (same pivot trick as the rotated text-box member), with the content
+  // re-offset so the box stays centered under the rotation.
+  let target: IGroup = tree;
+  let ox = boxX;
+  let oy = boxY;
+  if (drawing.rotation) {
+    const spinner = new Group({
+      x: boxX + drawing.width / 2,
+      y: boxY + drawing.height / 2,
+      rotation: drawing.rotation,
+    });
+    tree.add(spinner);
+    target = spinner;
+    ox = -drawing.width / 2;
+    oy = -drawing.height / 2;
+  }
   if (drawing.clipMembers) {
     // A srcRect-cropped metafile replay reaches past the extent (GDI clips
     // metafile playback to the rect); wps text boxes must NOT clip — their
     // text may legitimately overflow a stale declared extent. Leafer clips
     // children only on a Box (`overflow` is Box data, Group ignores it).
     const holder = new Box({
-      x: boxX,
-      y: boxY,
+      x: ox,
+      y: oy,
       width: drawing.width,
       height: drawing.height,
       overflow: "hide",
     });
     paintMembers(holder, drawing.members, 0, 0, ctx);
-    tree.add(holder);
+    target.add(holder);
   } else {
-    paintMembers(tree, drawing.members, boxX, boxY, ctx);
+    paintMembers(target, drawing.members, ox, oy, ctx);
   }
 }
 

--- a/packages/docx/src/layout/project/drawing.ts
+++ b/packages/docx/src/layout/project/drawing.ts
@@ -450,6 +450,7 @@ function projectDrawing(group: GroupOptions, ctx: ProjectContext): LayoutDrawing
   const extW = measureEmu(group.transformation.width);
   const extH = measureEmu(group.transformation.height);
   if (extW == null || extH == null || extW <= 0 || extH <= 0) return undefined;
+  const rotation = group.transformation.rotation;
   const { anchor, wrap, wrapSide, contour, behind, zIndex, distances } = drawingAnchorOf(
     group.floating,
     emuToPx(extW),
@@ -495,6 +496,7 @@ function projectDrawing(group: GroupOptions, ctx: ProjectContext): LayoutDrawing
     behind,
     ...(zIndex != null ? { zIndex } : {}),
     distances,
+    ...(rotation ? { rotation } : {}),
   };
 }
 
@@ -624,6 +626,7 @@ function projectFloatingPicture(pic: Rec): LayoutDrawing | undefined {
     behind,
     ...(zIndex != null ? { zIndex } : {}),
     distances,
+    ...(typeof tr.rotation === "number" && tr.rotation ? { rotation: tr.rotation } : {}),
     // A srcRect-cropped metafile replay reaches past the extent — flag it so
     // the painter clips (GDI playback semantics); the flat member never does.
     ...(crop ? { clipMembers: true } : {}),
@@ -670,6 +673,7 @@ function projectWpsShapeRun(wps: Rec, ctx: ProjectContext): LayoutDrawing | unde
     behind,
     ...(zIndex != null ? { zIndex } : {}),
     distances,
+    ...(typeof tr.rotation === "number" && tr.rotation ? { rotation: tr.rotation } : {}),
   };
 }
 

--- a/packages/editor/src/document/canvas/drawing-editor/geometry.spec.ts
+++ b/packages/editor/src/document/canvas/drawing-editor/geometry.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { handleAt, resizeBox, type Box } from "./geometry";
+import { handleAt, resizeBox, rotateDelta, type Box } from "./geometry";
 
 const box: Box = { x: 100, y: 80, width: 200, height: 100 };
 
@@ -56,5 +56,24 @@ describe("resizeBox", () => {
     expect(next.y).toBe(180 - 24);
     expect(next.width).toBe(24);
     expect(next.height).toBe(24);
+  });
+});
+
+describe("rotateDelta", () => {
+  const c = 0; // center at the origin
+
+  it("measures the clockwise sweep between two pointer positions", () => {
+    // Screen px: +y is DOWN, so right→below sweeps +90° (clockwise).
+    expect(rotateDelta(c, c, 50, 0, 0, 50)).toBe(90);
+    expect(rotateDelta(c, c, 50, 0, 0, -50)).toBe(-90);
+    expect(rotateDelta(c, c, 50, 0, 50, 0)).toBe(0);
+  });
+
+  it("keeps the spin continuous across the ±180° wrap", () => {
+    // Left of the center is atan2's 180° boundary; stepping to the top is a
+    // +90° clockwise sweep, not a -270° rewind.
+    expect(rotateDelta(c, c, -50, 0, 0, -50)).toBe(90);
+    // And counter-clockwise over the same boundary stays negative.
+    expect(rotateDelta(c, c, 0, -50, -50, 0)).toBe(-90);
   });
 });

--- a/packages/editor/src/document/canvas/drawing-editor/geometry.ts
+++ b/packages/editor/src/document/canvas/drawing-editor/geometry.ts
@@ -98,3 +98,24 @@ export function resizeBox(box: Box, handle: HandleId, dx: number, dy: number, mi
   }
   return { x: positive(x), y: positive(y), width: positive(width), height: positive(height) };
 }
+
+/** The clockwise angle (degrees) the pointer swept around the box center
+ *  from point a to point b, normalized to (-180, 180] — one gesture step's
+ *  delta (the caller accumulates per pointer-move, so the normalization
+ *  keeps the spin continuous across the ±180° wrap). Screen px; the angle
+ *  is scale-free. */
+export function rotateDelta(
+  cx: number,
+  cy: number,
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number,
+): number {
+  const a = (Math.atan2(ay - cy, ax - cx) * 180) / Math.PI;
+  const b = (Math.atan2(by - cy, bx - cx) * 180) / Math.PI;
+  const delta = b - a;
+  if (delta > 180) return delta - 360;
+  if (delta <= -180) return delta + 360;
+  return delta;
+}

--- a/packages/editor/src/document/canvas/drawing-editor/overlay.ts
+++ b/packages/editor/src/document/canvas/drawing-editor/overlay.ts
@@ -1,4 +1,4 @@
-import { HANDLES, resizeBox, type Box, type HandleId } from "./geometry";
+import { HANDLES, resizeBox, rotateDelta, type Box, type HandleId } from "./geometry";
 
 /**
  * The drawing selection frame — Word's picture selection: a border plus eight
@@ -14,18 +14,21 @@ import { HANDLES, resizeBox, type Box, type HandleId } from "./geometry";
 /** Host-provided I/O: read the scale (page px → screen px), and apply a box
  *  the user dragged to. `applyBox` returns false to reject (e.g. a read-only
  *  doc) — the frame snaps back on the next show/refresh. `applyOffset` moves
- *  the drawing by a drag delta (a floating drawing's move); absent, the
- *  frame stays put on a body drag. */
+ *  the drawing by a drag delta (a floating drawing's move); `applyRotation`
+ *  spins it by a handle-swept delta (degrees, clockwise); absent, the frame
+ *  stays put on a body drag. */
 export interface DrawingOverlayCallbacks {
   scale(): number;
   applyBox(box: Box): void;
   applyOffset?(dx: number, dy: number): void;
+  applyRotation?(delta: number): void;
 }
 
 export class DrawingOverlay {
   readonly el: HTMLDivElement;
   #callbacks: DrawingOverlayCallbacks;
   #box: Box | null = null;
+  #rotation = 0;
   #drag: { handle: HandleId; startX: number; startY: number; origin: Box } | null = null;
   #handles = new Map<HandleId, HTMLDivElement>();
 
@@ -69,22 +72,43 @@ export class DrawingOverlay {
       this.el.append(h);
       h.addEventListener("pointerdown", (e) => this.#onHandleDown(id, e));
     }
+    // Word's rotate handle: a round grip on a stem above the frame's top
+    // edge, spinning the drawing about its center.
+    const rot = document.createElement("div");
+    rot.dataset.handle = "rot";
+    Object.assign(rot.style, {
+      position: "absolute",
+      left: "calc(50% - 5px)",
+      top: "-28px",
+      width: "10px",
+      height: "10px",
+      boxSizing: "border-box",
+      borderRadius: "50%",
+      background: "#fff",
+      border: "1.5px solid #2b7cd3",
+      pointerEvents: "auto",
+      cursor: "grab",
+    } satisfies Partial<CSSStyleDeclaration>);
+    rot.addEventListener("pointerdown", (e) => this.#onRotateDown(e));
+    this.el.append(rot);
     this.el.addEventListener("pointermove", (e) => this.#onPointerMove(e));
     for (const kind of ["pointerup", "pointercancel"] as const)
       this.el.addEventListener(kind, () => this.#onDragEnd());
   }
 
-  /** Show the frame over `box` (page-local px at scale 1). */
-  show(box: Box): void {
+  /** Show the frame over `box` (page-local px at scale 1), tilted by
+   *  `rotation` degrees when the drawing is rotated. */
+  show(box: Box, rotation = 0): void {
     this.#box = box;
+    this.#rotation = rotation;
     this.el.style.display = "block";
     this.#place();
   }
 
   /** Refresh after the box changed underneath (a re-render, an applied drag). */
-  refresh(box: Box | null): void {
+  refresh(box: Box | null, rotation = 0): void {
     if (!box) return this.hide();
-    this.show(box);
+    this.show(box, rotation);
   }
 
   hide(): void {
@@ -101,6 +125,10 @@ export class DrawingOverlay {
     this.el.style.top = `${box.y * scale}px`;
     this.el.style.width = `${box.width * scale}px`;
     this.el.style.height = `${box.height * scale}px`;
+    // The frame tilts with the drawing (Word's rotated selection): a CSS
+    // rotate about the frame's center matches the painter's pivot, and the
+    // handles ride along.
+    this.el.style.transform = `rotate(${this.#rotation}deg)`;
   }
 
   #onHandleDown(handle: HandleId, event: PointerEvent): void {
@@ -135,6 +163,39 @@ export class DrawingOverlay {
     if (!drag || !this.#box) return;
     this.#drag = null;
     this.#callbacks.applyBox(this.#box);
+  }
+
+  /** Start a rotate drag from the rotate handle: each pointer move adds its
+   *  swept angle around the frame center (screen px, so zoom-independent)
+   *  to the spin, and release commits the accumulated degrees. */
+  #onRotateDown(event: PointerEvent): void {
+    if (!this.#box) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const rect = this.el.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const origin = this.#rotation;
+    let prevX = event.clientX;
+    let prevY = event.clientY;
+    let total = 0;
+    const onMove = (e: PointerEvent): void => {
+      total += rotateDelta(cx, cy, prevX, prevY, e.clientX, e.clientY);
+      prevX = e.clientX;
+      prevY = e.clientY;
+      this.#rotation = origin + total;
+      this.#place();
+    };
+    const onUp = (): void => {
+      document.removeEventListener("pointermove", onMove);
+      document.removeEventListener("pointerup", onUp);
+      document.removeEventListener("pointercancel", onUp);
+      const delta = Math.round(total);
+      if (delta !== 0) this.#callbacks.applyRotation?.(delta);
+    };
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", onUp);
+    document.addEventListener("pointercancel", onUp);
   }
 
   /** True while a frame is shown (a selected drawing on screen). */

--- a/packages/editor/src/document/canvas/edit-bridge.ts
+++ b/packages/editor/src/document/canvas/edit-bridge.ts
@@ -178,6 +178,8 @@ interface DrawingHit {
   y: number;
   width: number;
   height: number;
+  /** Clockwise degrees — the selection frame tilts with the drawing. */
+  rotation?: number;
 }
 
 export interface EditBridge {
@@ -733,6 +735,12 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
         JSON.stringify({ h: Math.round(dx * EMU_PER_PX), v: Math.round(dy * EMU_PER_PX) }),
       );
     },
+    applyRotation: (delta) => {
+      if (!selDrawing) return;
+      const nodePos = opts.drawingSelection?.(selDrawing) ?? null;
+      if (nodePos == null) return;
+      main.editor.commands["rotate-drawing"](JSON.stringify(delta));
+    },
   });
   opts.host.append(drawingOverlay.el);
 
@@ -747,7 +755,7 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
       return;
     }
     if (frame !== drawingOverlay.el.parentElement) frame.append(drawingOverlay.el);
-    drawingOverlay.refresh(selDrawing);
+    drawingOverlay.refresh(selDrawing, selDrawing.rotation);
   };
 
   const selectDrawing = (hit: DrawingHit): void => {

--- a/packages/editor/src/document/canvas/stage.ts
+++ b/packages/editor/src/document/canvas/stage.ts
@@ -1103,13 +1103,26 @@ export class CanvasStage {
   private readonly hitBoxes = new Map<number, DrawingHitBox[]>();
 
   /** The topmost drawing whose painted box contains the page-local point
-   *  (null when none does) — later-painted wins, Word's z-click. */
+   *  (null when none does) — later-painted wins, Word's z-click. A rotated
+   *  box hit-tests in its own space: the point un-rotates about the box
+   *  center before the rectangle check. */
   drawingAt(page: number, lx: number, ly: number): DrawingHitBox | null {
     const boxes = this.hitBoxes.get(page);
     if (!boxes) return null;
     for (let i = boxes.length - 1; i >= 0; i--) {
       const b = boxes[i]!;
-      if (lx >= b.x && lx <= b.x + b.width && ly >= b.y && ly <= b.y + b.height) return b;
+      let px = lx;
+      let py = ly;
+      if (b.rotation) {
+        const rad = (-b.rotation * Math.PI) / 180;
+        const cx = b.x + b.width / 2;
+        const cy = b.y + b.height / 2;
+        const dx = lx - cx;
+        const dy = ly - cy;
+        px = cx + dx * Math.cos(rad) - dy * Math.sin(rad);
+        py = cy + dx * Math.sin(rad) + dy * Math.cos(rad);
+      }
+      if (px >= b.x && px <= b.x + b.width && py >= b.y && py <= b.y + b.height) return b;
     }
     return null;
   }

--- a/packages/editor/src/document/extensions/commands.spec.ts
+++ b/packages/editor/src/document/extensions/commands.spec.ts
@@ -795,53 +795,54 @@ describe("add-text — TOC level stamps", () => {
   });
 });
 
+/** An offset-anchored floating picture in its own paragraph (Word's anchor
+ *  run shape — the image node is inline-only). */
+const buildWithFloat = (floating: object): EditorType =>
+  new Editor({
+    element: null,
+    extensions: EXTENSIONS,
+    content: {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "image",
+              attrs: { src: "data:,", width: 10, height: 10, floating },
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+/** Select the document's first image (the float the helpers build). */
+const selectFloat = (editor: EditorType): void => {
+  let pos = -1;
+  editor.state.doc.descendants((node, nodePos) => {
+    if (node.type.name === "image" && pos < 0) {
+      pos = nodePos;
+      return false;
+    }
+    return true;
+  });
+  editor.commands.setNodeSelection(pos);
+};
+
+const floatOf = (editor: EditorType): Record<string, unknown> => {
+  let floating: unknown;
+  editor.state.doc.descendants((node) => {
+    if (node.type.name === "image" && floating === undefined) {
+      floating = (node.attrs as Record<string, unknown>).floating;
+      return false;
+    }
+    return true;
+  });
+  return floating as Record<string, unknown>;
+};
+
 describe("move-drawing", () => {
-  /** An offset-anchored floating picture in its own paragraph (Word's anchor
-   *  run shape — the image node is inline-only). */
-  const buildWithFloat = (floating: object): EditorType =>
-    new Editor({
-      element: null,
-      extensions: EXTENSIONS,
-      content: {
-        type: "doc",
-        content: [
-          {
-            type: "paragraph",
-            content: [
-              {
-                type: "image",
-                attrs: { src: "data:,", width: 10, height: 10, floating },
-              },
-            ],
-          },
-        ],
-      },
-    });
-
-  const selectFloat = (editor: EditorType): void => {
-    let pos = -1;
-    editor.state.doc.descendants((node, nodePos) => {
-      if (node.type.name === "image" && pos < 0) {
-        pos = nodePos;
-        return false;
-      }
-      return true;
-    });
-    editor.commands.setNodeSelection(pos);
-  };
-
-  const floatOf = (editor: EditorType): Record<string, unknown> => {
-    let floating: unknown;
-    editor.state.doc.descendants((node) => {
-      if (node.type.name === "image" && floating === undefined) {
-        floating = (node.attrs as Record<string, unknown>).floating;
-        return false;
-      }
-      return true;
-    });
-    return floating as Record<string, unknown>;
-  };
-
   it("adds the drag delta (EMU) to the selected drawing's offsets", () => {
     const editor = buildWithFloat({
       horizontalPosition: { relative: "margin", offset: 1000 },
@@ -900,5 +901,72 @@ describe("move-drawing", () => {
     selectFloat(editor);
     expect(editor.commands["move-drawing"]("not json")).toBe(false);
     expect(editor.commands["move-drawing"]()).toBe(false);
+  });
+});
+
+describe("rotate-drawing", () => {
+  const FLOATING = {
+    horizontalPosition: { relative: "margin", offset: 1000 },
+    verticalPosition: { relative: "paragraph", offset: 2000 },
+  };
+
+  it("adds the swept degrees to the selected floating image's rotation", () => {
+    const editor = buildWithFloat(FLOATING);
+    selectFloat(editor);
+    expect(editor.commands["rotate-drawing"](JSON.stringify(45))).toBe(true);
+    expect(firstNodeOf(editor, "image").attrs.rotation).toBe(45);
+    // The sweep accumulates onto the drawing's current angle.
+    expect(editor.commands["rotate-drawing"](JSON.stringify(-90))).toBe(true);
+    expect(firstNodeOf(editor, "image").attrs.rotation).toBe(-45);
+    expect(editor.state.selection instanceof NodeSelection).toBe(true);
+  });
+
+  it("rotates a floating wps shape through its payload's transformation", () => {
+    const editor = new Editor({
+      element: null,
+      extensions: EXTENSIONS,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "wpsShape",
+                attrs: {
+                  wpsShape: {
+                    floating: FLOATING,
+                    transformation: { width: 914400, height: 914400, rotation: 30 },
+                  },
+                },
+                // The shape's editable text body (a block+) rides the node.
+                content: [{ type: "paragraph" }],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    let pos = -1;
+    editor.state.doc.descendants((node, nodePos) => {
+      if (node.type.name === "wpsShape" && pos < 0) {
+        pos = nodePos;
+        return false;
+      }
+      return true;
+    });
+    editor.commands.setNodeSelection(pos);
+    expect(editor.commands["rotate-drawing"](JSON.stringify(15))).toBe(true);
+    const shape = firstNodeOf(editor, "wpsShape").attrs.wpsShape as Record<string, unknown>;
+    expect((shape.transformation as Record<string, unknown>).rotation).toBe(45);
+  });
+
+  it("declines without a floating drawing selected or a zero sweep", () => {
+    const editor = buildWithFloat(FLOATING);
+    expect(editor.commands["rotate-drawing"](JSON.stringify(45))).toBe(false);
+    selectFloat(editor);
+    expect(editor.commands["rotate-drawing"](JSON.stringify(0))).toBe(false);
+    expect(editor.commands["rotate-drawing"]("nan")).toBe(false);
+    expect(editor.commands["rotate-drawing"]()).toBe(false);
   });
 });

--- a/packages/editor/src/document/extensions/commands.ts
+++ b/packages/editor/src/document/extensions/commands.ts
@@ -124,6 +124,7 @@ declare module "@tiptap/core" {
       "delete-picture": () => ReturnType;
       "position-picture": (value?: string) => ReturnType;
       "move-drawing": (value?: string) => ReturnType;
+      "rotate-drawing": (value?: string) => ReturnType;
       // Arrange — floating drawings (z-order, wrap, rotation, position).
       "bring-forward": () => ReturnType;
       "send-backward": () => ReturnType;
@@ -213,6 +214,7 @@ export const WIRED_DISPATCH: ReadonlySet<string> = new Set([
   "delete-picture",
   "position-picture",
   "move-drawing",
+  "rotate-drawing",
   "bring-forward",
   "send-backward",
   "wrap",
@@ -2438,6 +2440,34 @@ export const DocumentCommands = Extension.create({
             ...floating,
             horizontalPosition: { ...h, offset: h.offset + (parsed.h ?? 0) },
             verticalPosition: { ...v, offset: v.offset + (parsed.v ?? 0) },
+          });
+        },
+      // Rotate the selected floating drawing by a handle-swept delta: value
+      // is the degrees to add to the drawing's current rotation (clockwise;
+      // image: the flat rotation attr, shape: its payload's transformation).
+      "rotate-drawing":
+        (value?) =>
+        ({ state, tr }) => {
+          const delta = value == null ? Number.NaN : Number(value);
+          if (!Number.isFinite(delta) || delta === 0) return false;
+          const target = floatingDrawingAt(state);
+          if (!target) return false;
+          if (target.kind === "image") {
+            const current = target.attrs.rotation;
+            return stampAttrs(tr, target, {
+              ...target.attrs,
+              rotation: (typeof current === "number" ? current : 0) + delta,
+            });
+          }
+          const shape = target.attrs.wpsShape as Record<string, unknown>;
+          const transformation = {
+            ...(shape.transformation as Record<string, unknown> | undefined),
+          };
+          const current = transformation.rotation;
+          transformation.rotation = (typeof current === "number" ? current : 0) + delta;
+          return stampAttrs(tr, target, {
+            ...target.attrs,
+            wpsShape: { ...shape, transformation },
           });
         },
       // ── Arrange — floating drawings (the Layout tab's Arrange group) ──

--- a/packages/layout/src/layout-doc/drawing.ts
+++ b/packages/layout/src/layout-doc/drawing.ts
@@ -175,6 +175,10 @@ export interface LayoutDrawing {
    *  playback semantics — records past the crop line never draw). Absent on
    *  wps text boxes: their text may overflow a stale declared extent. */
   clipMembers?: boolean;
+  /** Clockwise rotation of the whole drawing about its box center, degrees
+   *  (a:xfrm @rot). The flow's wrap box stays the unrotated extent — Word
+   *  wraps text by the extent, not the rotated ink. */
+  rotation?: number;
 }
 
 /** A drawing's wrap box: its extent grown by the anchor's wrap distances,


### PR DESCRIPTION
## Summary

- Word's picture rotate handle on the drawing selection frame: a round grip on a stem above the top edge; dragging it spins the floating drawing about its center
- Swept angle accumulates per pointer move with normalized frame deltas, so the spin stays continuous across the 180-degree wrap; release commits one undoable step
- Rotation persists in the drawing's options (the image `rotation` attr / the shape payload's `transformation.rotation`), re-projects through layout, and paints as a group pivoted at the box center (the wrap box stays the unrotated extent, matching Word)
- The selection frame tilts with the drawing (CSS rotate, handles ride along) and click hit-testing un-rotates the point into the box's own space

## Verification

- Unit: `rotateDelta` sweep/wrap cases + `rotate-drawing` command cases (image increment, shape transformation, decline paths) — 138/138 green in the editor package
- Browser end-to-end on the demo's floating cat: drag top-to-right commits `rotation: 90`, canvas paint shows the cat turned, mid-gesture transform tracks (44.99 to 89.99), the selection frame keeps its tilt after refresh, a click at the box center still selects after rotation, and Ctrl+Z restores the unrotated frame with `rotation: null`

Inline images decline for now (their paint path has no pivot); tracked for a follow-up.
