### PR TITLE
feat(editor): cut and copy a drawing from its context menu

### DIFF
--- a/packages/editor/src/document/index.ts
+++ b/packages/editor/src/document/index.ts
@@ -2512,6 +2512,11 @@ class DocenDocument extends AddinHost<Editor> {
     // instead of the text menu — the caret-based branches below never run.
     if (this.#bridge?.selectDrawingAtClient(event.clientX, event.clientY)) {
       const items: RibbonMenuItem[] = [];
+      // The clipboard entries work on a NodeSelection: the slice payload
+      // carries the whole drawing, deleteSelection cuts it.
+      items.push({ text: t("context.cut", this), event: "cut" });
+      items.push({ text: t("context.copy", this), event: "copy" });
+      items.push({ text: "-" });
       items.push({ text: t("context.bring-forward", this), event: "bring-forward" });
       items.push({ text: t("context.send-backward", this), event: "send-backward" });
       items.push({ text: "-" });


### PR DESCRIPTION
## Summary

- The picture context menu gains Cut and Copy: both act on the NodeSelection through the same slice-payload lane the keyboard shortcuts use, so a drawing pastes back with all of its options (floating anchor, size, rotation) intact
- No new clipboard machinery — the copy/cut command routing and the pin fallback already handled a node selection; this wires the menu entries to it

## Verification

- Browser end-to-end: right-click shows the five-item menu (Cut / Copy / Bring Forward / Send Backward / Delete Picture); Copy from the menu, paste in a body paragraph → drawing count 1 → 2; Ctrl+X removes it (1 → 0), Ctrl+V pastes it back (0 → 1), double Ctrl+Z rolls both steps back cleanly (1 → 0 → 1)
- Editor package: 138/138 tests green, check green
