### PR TITLE
feat(editor): inline picture rotation and align-float drag

### DIFF
--- a/packages/core/src/paint/paragraph.ts
+++ b/packages/core/src/paint/paragraph.ts
@@ -15,7 +15,17 @@ import {
   type LayoutParagraphBorderEdge,
   type LayoutTextStyle,
 } from "@docen/layout";
-import { Box, Ellipse, Image as LeaferImage, Line, Path, Rect, Text, type IGroup } from "leafer-ui";
+import {
+  Box,
+  Ellipse,
+  Group,
+  Image as LeaferImage,
+  Line,
+  Path,
+  Rect,
+  Text,
+  type IGroup,
+} from "leafer-ui";
 
 import type { PaintColumn, PaintContext } from "./context";
 import { paintDrawing, paintMembers, recordDrawingHit } from "./drawing";
@@ -524,7 +534,27 @@ export function paintParagraph(
           para,
           index: inlinePicIndex++,
           kind: "inline",
+          ...(inline.rotation ? { rotation: inline.rotation } : {}),
         });
+        // A rotated picture spins about the extent's center — a group parked
+        // at the center carries the angle (the floating drawing's pivot) and
+        // the content re-offsets so the box stays centered under it.
+        const picX = lineX + item.xPx;
+        const picY = lineY + pad;
+        let target: IGroup = tree;
+        let ox = picX;
+        let oy = picY;
+        if (inline.rotation) {
+          const spinner = new Group({
+            x: picX + item.widthPx / 2,
+            y: picY + item.heightPx / 2,
+            rotation: inline.rotation,
+          });
+          tree.add(spinner);
+          target = spinner;
+          ox = -item.widthPx / 2;
+          oy = -item.heightPx / 2;
+        }
         if (inline.members) {
           // A metafile source replayed into members (WMF vector layers): the
           // structured scene paints in place of the flat image, clipped to
@@ -533,44 +563,44 @@ export function paintParagraph(
           // Group ignores `overflow` (a Box-only data getter clips children),
           // so the clip holder must be a Box.
           const holder = new Box({
-            x: lineX + item.xPx,
-            y: lineY + pad,
+            x: ox,
+            y: oy,
             width: item.widthPx,
             height: item.heightPx,
             overflow: "hide",
           });
           paintMembers(holder, inline.members, 0, 0, ctx);
-          tree.add(holder);
+          target.add(holder);
         } else if (inline.src && inline.crop) {
           // A cropped flat source (a:srcRect): the visible remainder fills
           // the extent box — the whole source would stretch into it.
           addCroppedImage(
-            tree,
+            target,
             inline.src,
             inline.crop,
-            lineX + item.xPx,
-            lineY + pad,
+            ox,
+            oy,
             item.widthPx,
             item.heightPx,
             ctx,
           );
         } else if (inline.src) {
           pinImage(inline.src);
-          tree.add(
+          target.add(
             new LeaferImage({
               url: inline.src,
-              x: lineX + item.xPx,
-              y: lineY + pad,
+              x: ox,
+              y: oy,
               width: item.widthPx,
               height: item.heightPx,
             }),
           );
         } else {
           // Linked-only picture (no bytes in the package): an empty frame.
-          tree.add(
+          target.add(
             new Rect({
-              x: lineX + item.xPx,
-              y: lineY + pad,
+              x: ox,
+              y: oy,
               width: item.widthPx,
               height: item.heightPx,
               fill: "#f3f3f3",

--- a/packages/docx/src/layout/project.spec.ts
+++ b/packages/docx/src/layout/project.spec.ts
@@ -231,6 +231,35 @@ describe("projectDocumentOptions style cascade", () => {
     });
   });
 
+  it("carries an inline picture's a:xfrm rotation into the projection", () => {
+    const { blocks } = oneSection(
+      doc([
+        {
+          paragraph: {
+            children: [
+              {
+                picture: {
+                  type: "png",
+                  data: "x",
+                  transformation: { width: 609600, height: 457200, rotation: 45 },
+                },
+              },
+            ],
+          },
+        },
+      ]),
+    );
+    const para = blocks[0];
+    if (para?.kind !== "paragraph") throw new Error("expected paragraph");
+    expect(para.inline[0]).toEqual({
+      kind: "picture",
+      widthPx: 64,
+      heightPx: 48,
+      src: "data:image/png;base64,x",
+      rotation: 45,
+    });
+  });
+
   it("projects run color and underline/strike decorations", () => {
     const { blocks } = oneSection(
       doc([

--- a/packages/docx/src/layout/project/runs.ts
+++ b/packages/docx/src/layout/project/runs.ts
@@ -269,6 +269,9 @@ export function projectRuns(
         src: members ? undefined : pictureSrc(pic),
         crop: members ? undefined : cropOf(pic),
         members,
+        // a:xfrm @rot (degrees) — Word tilts inline pictures about the
+        // extent's center just like floating ones.
+        ...(typeof tr.rotation === "number" && tr.rotation !== 0 ? { rotation: tr.rotation } : {}),
       });
     }
   };

--- a/packages/editor/src/document/canvas/edit-bridge.ts
+++ b/packages/editor/src/document/canvas/edit-bridge.ts
@@ -740,8 +740,22 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
       if (!selDrawing) return;
       const nodePos = opts.drawingSelection?.(selDrawing) ?? null;
       if (nodePos == null) return;
-      main.editor.commands["move-drawing"](
-        JSON.stringify({ h: Math.round(dx * EMU_PER_PX), v: Math.round(dy * EMU_PER_PX) }),
+      const hEmu = Math.round(dx * EMU_PER_PX);
+      const vEmu = Math.round(dy * EMU_PER_PX);
+      // An offset-anchored float adds the drag delta to its offsets; an
+      // align-anchored one has none to add to — the drop lands absolute,
+      // page-anchored, at the dragged spot (Word: dragging breaks the
+      // alignment, the drawn result doesn't shift).
+      const anchors = selectedFloatingAnchors();
+      if (typeof anchors?.h?.offset === "number" && typeof anchors.v?.offset === "number") {
+        main.editor.commands["move-drawing"](JSON.stringify({ h: hEmu, v: vEmu }));
+        return;
+      }
+      main.editor.commands["place-drawing"](
+        JSON.stringify({
+          h: Math.round(selDrawing.x * EMU_PER_PX) + hEmu,
+          v: Math.round(selDrawing.y * EMU_PER_PX) + vEmu,
+        }),
       );
     },
     applyRotation: (delta) => {
@@ -837,12 +851,15 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
    *  nearest line regardless of distance — a drag overshooting past the
    *  last line's band must keep extending to the line's end (Word), not
    *  stall the selection mid-line. */
-  /** Whether the selection is a floating drawing both axes anchor by EMU
-   *  offset — the only anchoring a pointer drag can express. Align-anchored
-   *  (and inline) drawings decline: their position isn't an offset. */
-  const movableFloating = (): boolean => {
+  /** The selected floating drawing's position anchors (null on any other
+   *  selection) — any float can start a pointer drag; whether the drop adds
+   *  a delta or lands absolute depends on the anchor shape. */
+  const selectedFloatingAnchors = (): {
+    h: Record<string, unknown> | undefined;
+    v: Record<string, unknown> | undefined;
+  } | null => {
     const sel = main.editor.state.selection;
-    if (!(sel instanceof NodeSelection)) return false;
+    if (!(sel instanceof NodeSelection)) return null;
     const attrs = sel.node.attrs as Record<string, unknown>;
     const floating =
       sel.node.type.name === "image"
@@ -851,11 +868,15 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
             string,
             unknown
           > | null);
-    if (!floating) return false;
-    const h = floating.horizontalPosition as Record<string, unknown> | undefined;
-    const v = floating.verticalPosition as Record<string, unknown> | undefined;
-    return typeof h?.offset === "number" && typeof v?.offset === "number";
+    if (!floating) return null;
+    return {
+      h: floating.horizontalPosition as Record<string, unknown> | undefined,
+      v: floating.verticalPosition as Record<string, unknown> | undefined,
+    };
   };
+
+  /** Whether the selection is a floating drawing a pointer drag can move. */
+  const movableFloating = (): boolean => selectedFloatingAnchors() != null;
 
   const posAtClient = (clientX: number, clientY: number, clamp = false): number | null => {
     const s = active();

--- a/packages/editor/src/document/extensions/commands.spec.ts
+++ b/packages/editor/src/document/extensions/commands.spec.ts
@@ -961,6 +961,28 @@ describe("rotate-drawing", () => {
     expect((shape.transformation as Record<string, unknown>).rotation).toBe(45);
   });
 
+  it("rotates an inline image through the same flat attr", () => {
+    // Word spins an inline picture about its extent's center exactly like a
+    // floating one — the rotation attr carries either way.
+    const editor = new Editor({
+      element: null,
+      extensions: EXTENSIONS,
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "image", attrs: { src: "data:,", width: 10, height: 10 } }],
+          },
+        ],
+      },
+    });
+    selectFloat(editor);
+    expect(editor.commands["rotate-drawing"](JSON.stringify(30))).toBe(true);
+    expect(firstNodeOf(editor, "image").attrs.rotation).toBe(30);
+    expect(editor.state.selection instanceof NodeSelection).toBe(true);
+  });
+
   it("declines without a floating drawing selected or a zero sweep", () => {
     const editor = buildWithFloat(FLOATING);
     expect(editor.commands["rotate-drawing"](JSON.stringify(45))).toBe(false);
@@ -968,6 +990,47 @@ describe("rotate-drawing", () => {
     expect(editor.commands["rotate-drawing"](JSON.stringify(0))).toBe(false);
     expect(editor.commands["rotate-drawing"]("nan")).toBe(false);
     expect(editor.commands["rotate-drawing"]()).toBe(false);
+  });
+});
+
+describe("place-drawing", () => {
+  const FLOATING = {
+    horizontalPosition: { relative: "margin", offset: 1000 },
+    verticalPosition: { relative: "paragraph", offset: 2000 },
+  };
+
+  it("lands an align-anchored float as page-anchored offsets", () => {
+    const editor = buildWithFloat({
+      horizontalPosition: { relative: "margin", align: "center" },
+      verticalPosition: { relative: "page", align: "top" },
+    });
+    selectFloat(editor);
+    expect(editor.commands["place-drawing"](JSON.stringify({ h: 914400, v: 1828800 }))).toBe(true);
+    const floating = floatOf(editor);
+    // The painted spot IS the value: relative flips to page, the offset
+    // replaces the alignment outright.
+    expect(floating.horizontalPosition).toEqual({ relative: "page", offset: 914400 });
+    expect(floating.verticalPosition).toEqual({ relative: "page", offset: 1828800 });
+    expect(editor.state.selection instanceof NodeSelection).toBe(true);
+  });
+
+  it("also accepts an offset-anchored float (the bridge's dispatch is by anchor)", () => {
+    const editor = buildWithFloat(FLOATING);
+    selectFloat(editor);
+    expect(editor.commands["place-drawing"](JSON.stringify({ h: 1, v: 2 }))).toBe(true);
+    const floating = floatOf(editor);
+    expect(floating.horizontalPosition).toEqual({ relative: "page", offset: 1 });
+  });
+
+  it("declines malformed or incomplete values and non-floating selections", () => {
+    const editor = buildWithFloat(FLOATING);
+    selectFloat(editor);
+    expect(editor.commands["place-drawing"]("not json")).toBe(false);
+    expect(editor.commands["place-drawing"](JSON.stringify({ h: 1 }))).toBe(false);
+    expect(editor.commands["place-drawing"]()).toBe(false);
+    // Without the drawing selected there is nothing to place.
+    editor.commands.setTextSelection(1);
+    expect(editor.commands["place-drawing"](JSON.stringify({ h: 1, v: 2 }))).toBe(false);
   });
 });
 

--- a/packages/editor/src/document/extensions/commands.ts
+++ b/packages/editor/src/document/extensions/commands.ts
@@ -124,6 +124,7 @@ declare module "@tiptap/core" {
       "delete-picture": () => ReturnType;
       "position-picture": (value?: string) => ReturnType;
       "move-drawing": (value?: string) => ReturnType;
+      "place-drawing": (value?: string) => ReturnType;
       "rotate-drawing": (value?: string) => ReturnType;
       "drawing-properties-apply": (patch?: DrawingPropertiesPatch) => ReturnType;
       "drawing-crop-apply": (patch?: DrawingCropPatch) => ReturnType;
@@ -216,6 +217,7 @@ export const WIRED_DISPATCH: ReadonlySet<string> = new Set([
   "delete-picture",
   "position-picture",
   "move-drawing",
+  "place-drawing",
   "rotate-drawing",
   "drawing-properties-apply",
   "drawing-crop-apply",
@@ -2454,10 +2456,8 @@ export const DocumentCommands = Extension.create({
         },
       // Move a selected floating drawing (image or wps shape) by a pointer-
       // drag delta: value is JSON {h, v} in EMU, added to the drawing's
-      // current offsets. Align-anchored floats decline — the bridge only
-      // starts a drag when both axes anchor by offset (Word converts an
-      // alignment to an offset on drag; that needs the painted position,
-      // a later batch).
+      // current offsets. Align-anchored floats decline — the bridge commits
+      // those through place-drawing instead.
       "move-drawing":
         (value?) =>
         ({ state, tr }) => {
@@ -2481,23 +2481,53 @@ export const DocumentCommands = Extension.create({
             verticalPosition: { ...v, offset: v.offset + (parsed.v ?? 0) },
           });
         },
-      // Rotate the selected floating drawing by a handle-swept delta: value
-      // is the degrees to add to the drawing's current rotation (clockwise;
-      // image: the flat rotation attr, shape: its payload's transformation).
+      // Drop a dragged drawing at an absolute page position: value is JSON
+      // {h, v} in EMU, page-local. An align-anchored float has no offset for
+      // move-drawing to add to, so the drag lands as page-anchored offsets —
+      // the painted position IS the value (Word converts an alignment to an
+      // offset on drag; the drawn spot doesn't shift).
+      "place-drawing":
+        (value?) =>
+        ({ state, tr }) => {
+          if (!value) return false;
+          const target = floatingDrawingAt(state);
+          if (!target) return false;
+          let parsed: { h?: number; v?: number };
+          try {
+            parsed = JSON.parse(value) as { h?: number; v?: number };
+          } catch {
+            return false;
+          }
+          if (typeof parsed.h !== "number" || typeof parsed.v !== "number") return false;
+          return stampFloating(tr, target, {
+            ...floatingOf(target),
+            horizontalPosition: { relative: "page", offset: parsed.h },
+            verticalPosition: { relative: "page", offset: parsed.v },
+          });
+        },
+      // Rotate the selected drawing by a handle-swept delta: value is the
+      // degrees to add to the drawing's current rotation (clockwise; image:
+      // the flat rotation attr, floating or inline alike — the a:xfrm rot
+      // spins the extent box either way; shape: its payload's transformation,
+      // floating only).
       "rotate-drawing":
         (value?) =>
         ({ state, tr }) => {
           const delta = value == null ? Number.NaN : Number(value);
           if (!Number.isFinite(delta) || delta === 0) return false;
-          const target = floatingDrawingAt(state);
-          if (!target) return false;
-          if (target.kind === "image") {
-            const current = target.attrs.rotation;
+          const sel = state.selection;
+          if (!(sel instanceof NodeSelection)) return false;
+          if (sel.node.type.name === "image") {
+            const attrs = sel.node.attrs as Record<string, unknown>;
+            const target = { pos: sel.from, attrs, kind: "image" as const };
+            const current = attrs.rotation;
             return stampAttrs(tr, target, {
-              ...target.attrs,
+              ...attrs,
               rotation: (typeof current === "number" ? current : 0) + delta,
             });
           }
+          const target = floatingDrawingAt(state);
+          if (!target) return false;
           const shape = target.attrs.wpsShape as Record<string, unknown>;
           const transformation = {
             ...(shape.transformation as Record<string, unknown> | undefined),

--- a/packages/layout/src/layout-doc/inline.ts
+++ b/packages/layout/src/layout-doc/inline.ts
@@ -135,4 +135,7 @@ export type LayoutInline =
        * renderer paints these instead of loading `src` — same renderer-only
        * passthrough contract; the engine never reads beyond widthPx/heightPx. */
       members?: LayoutDrawingMember[];
+      /** Clockwise spin of the box about its center, degrees (a:xfrm @rot) —
+       * the extent stays put, the painted content tilts inside it. */
+      rotation?: number;
     };


### PR DESCRIPTION
## Summary

Two pointer-interaction gaps closed — the last planned items of the unified drawing editor:

**Inline picture rotation.** The projection dropped `a:xfrm @rot` for inline pictures, so the painter never spun the box and the rotate handle was a no-op on them. The degree now rides the line item; the painter reuses the floating drawing's pivot trick (a group parked at the extent's center with the content re-offset); the hit box carries the angle so the click's un-rotation applies too. `rotate-drawing` now spins a floating and an inline image alike — the flat rotation attr carries either way — while shapes stay floating-only. The XML round-trip (office-open compile/parse) already handled inline rot, so this is projection + paint + command only.

**Align-anchored float drag.** An align-anchored float declined the move drag — an alignment is not an offset to add to. Any float now starts the drag, and the drop dispatches by anchor shape: offset-anchored floats add the delta through `move-drawing` as before; align-anchored ones land through the new `place-drawing` command as page-anchored offsets at the dragged spot. Word converts the alignment to an offset on drag and the painted result doesn't shift — the painted position *is* the value.

## Verification

- Tests: layout 137, core (no specs), docx 190, editor 152 — all green, including new cases for the projection carrying rotation, the inline rotate write-back, and `place-drawing` (align → page offsets, offset-anchored acceptance, decline paths).
- `vp check` clean in all four packages.
- Browser end-to-end: the inline dog picture's rotate handle sweeps ~90° with the frame tilting and `attrs.rotation` written back in one step; the floating cat converted to `margin/center + margin/top` anchors drags to a new spot and lands as `{relative: "page", offset: …}` on both axes, one undo step each.
