### PR TITLE
fix(docx): allow negative firstLine indent to pass through unclamped

### DIFF
--- a/packages/docx/src/layout/project.spec.ts
+++ b/packages/docx/src/layout/project.spec.ts
@@ -1845,4 +1845,24 @@ describe("projectDocumentOptions page background", () => {
     // All-zero tile: full coverage of the gap color — the flat base itself.
     expect(projected?.color).toBe("F9F1E2");
   });
+
+  it("passes negative firstLine twips through unclamped", () => {
+    const projected = projectDocumentOptions(
+      doc([
+        {
+          paragraph: {
+            indent: { left: 720, firstLine: -720 },
+            children: ["Hanging indent with negative firstLine"],
+          },
+        },
+      ]),
+    );
+    const [sec] = projected.sections;
+    const [p] = sec.blocks;
+    expect(p.kind).toBe("paragraph");
+    if (p.kind === "paragraph") {
+      expect(p.indent?.leftPx).toBe(48);
+      expect(p.indent?.firstLinePx).toBe(-48);
+    }
+  });
 });

--- a/packages/docx/src/layout/project/paragraph.ts
+++ b/packages/docx/src/layout/project/paragraph.ts
@@ -145,7 +145,7 @@ export function projectParagraph(p: BodyParagraph, ctx: ProjectContext): LayoutP
     const directHanging = charsPx(dInd.hangingChars) ?? twPx(dInd.hanging);
     if (directHanging != null) return -directHanging;
     const directTw = twPx(dInd.firstLine);
-    if (directTw != null) return Math.max(0, directTw);
+    if (directTw != null) return directTw;
     const directChars = charsPx(dInd.firstLineChars);
     if (directChars != null) return directChars;
     if (level?.hangingTw != null && level.hangingTw > 0) return -twipToPx(level.hangingTw);
@@ -153,7 +153,7 @@ export function projectParagraph(p: BodyParagraph, ctx: ProjectContext): LayoutP
       charsPx(pick([sInd, docInd], "hangingChars")) ?? twPx(pick([sInd, docInd], "hanging"));
     if (styleHanging != null) return -styleHanging;
     const styleTw = twPx(pick([sInd, docInd], "firstLine"));
-    if (styleTw != null) return Math.max(0, styleTw);
+    if (styleTw != null) return styleTw;
     return charsPx(pick([sInd, docInd], "firstLineChars"));
   })();
   const indent = {


### PR DESCRIPTION
### Summary of Changes

Per maintainer review in #23, this PR is scoped strictly to removing the `Math.max(0, …)` clamps on `firstLine` in `packages/docx/src/layout/project/paragraph.ts`.

- **Negative `w:firstLine` Passthrough**:
  - In `packages/docx/src/layout/project/paragraph.ts`:
    - Removed `Math.max(0, directTw)` and `Math.max(0, styleTw)`.
    - Allows signed `ST_TwipsMeasure` negative first-line indents (e.g. emitted by third-party DOCX generators or pandoc for hanging indents) to pass through to `firstLinePx` without being clamped to `0`.
- **Test**:
  - In `packages/docx/src/layout/project.spec.ts`:
    - Added unit test verifying negative `firstLine` twips pass through unclamped as negative pixels (`indent: { left: 720, firstLine: -720 }` -> `leftPx: 48, firstLinePx: -48`).

### Verification
- `pnpm test` (`vp test run`): 35/35 test files passed (586/586 tests passed).
- `pnpm check` (`vp check --fix`): 0 warnings, 0 lint errors, 0 type errors across 277 files.
- `pnpm build`: Fully builds without errors.