### PR TITLE
feat(editor): robust table cell merge and split with content preservation

### DIFF
--- a/packages/editor/src/document/canvas/caret-map.ts
+++ b/packages/editor/src/document/canvas/caret-map.ts
@@ -129,6 +129,8 @@ export interface TableZone {
   colEdges: number[];
   /** Row top edges + the bottom rim (nRows + 1). */
   rowEdges: number[];
+  /** Document position of the ProseMirror table node (if mapped). */
+  tablePos?: number;
 }
 
 /** The cell content stack's first paragraph block — the position the PM zip
@@ -431,6 +433,31 @@ export class CaretMap {
       const boxes = this.cellBoxes.get(inner - 2);
       if (boxes) boxes.push(box);
       else this.cellBoxes.set(inner - 2, [box]);
+    }
+    const tableType = doc.type.schema.nodes.table;
+    if (tableType) {
+      for (const z of this.tableZones) {
+        for (const [cellPos, boxes] of this.cellBoxes) {
+          const box = boxes[0];
+          if (
+            box &&
+            box.page === z.page &&
+            box.xPx >= z.xPx - 1 &&
+            box.xPx + box.widthPx <= z.xPx + z.widthPx + 1 &&
+            box.yPx >= z.yPx - 1 &&
+            box.yPx + box.heightPx <= z.yPx + z.heightPx + 1
+          ) {
+            const $cell = doc.resolve(cellPos + 1);
+            for (let d = $cell.depth; d > 0; d -= 1) {
+              if ($cell.node(d).type === tableType) {
+                z.tablePos = $cell.before(d);
+                break;
+              }
+            }
+            if (z.tablePos != null) break;
+          }
+        }
+      }
     }
   }
 

--- a/packages/editor/src/document/canvas/cell-selection.ts
+++ b/packages/editor/src/document/canvas/cell-selection.ts
@@ -44,20 +44,20 @@ export function inSameTable(a: ResolvedPos, b: ResolvedPos): boolean {
 
 /** The (row, cell) sibling indexes of a cell position within its table —
  *  cellAt's resolve sits in the row layer, so depth is the row depth. */
-const rowCellOf = ($cell: ResolvedPos): { row: number; cell: number } => ({
+export const rowCellOf = ($cell: ResolvedPos): { row: number; cell: number } => ({
   row: $cell.index($cell.depth - 1),
   cell: $cell.index($cell.depth),
 });
 
 /** A cell's columnSpan — 1 unless the schema attr carries a wider one. */
-const spanOf = (cell: PmNode): number => {
+export const spanOf = (cell: PmNode): number => {
   const span = cell.attrs.columnSpan as unknown;
   return typeof span === "number" && span > 1 ? span : 1;
 };
 
 /** The grid column a row's cell sibling starts at — the spans of its
  *  preceding siblings (a spanning cell covers its columns). */
-const gridColOf = (rowNode: PmNode, cellIndex: number): number => {
+export const gridColOf = (rowNode: PmNode, cellIndex: number): number => {
   let col = 0;
   for (let i = 0; i < cellIndex; i += 1) col += spanOf(rowNode.child(i)!);
   return col;

--- a/packages/editor/src/document/canvas/edit-bridge.ts
+++ b/packages/editor/src/document/canvas/edit-bridge.ts
@@ -40,6 +40,16 @@ import { CellSelection, cellAt, inSameTable } from "./cell-selection";
 import { CropOverlay } from "./drawing-editor/crop-overlay";
 import { DrawingOverlay } from "./drawing-editor/overlay";
 import { followLink, installLinkHover, type LinkHit } from "./link-hover";
+import {
+  calcColumnResize,
+  calcRowResize,
+  calcTableScale,
+  hitTableElements,
+  PX_TO_TWIPS,
+  TWIPS_TO_PX,
+  type TableHit,
+} from "./table-geometry";
+import { TableCanvasOverlay } from "./table-overlay";
 
 /** A grapheme-boundary segmenter shared by the delete translations — surrogate
  *  pairs, combining marks, and emoji must delete as one user-perceived
@@ -995,21 +1005,286 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     gripEl.style.display = "block";
   };
 
+  type TableDrag =
+    | {
+        kind: "col";
+        zone: TableZone;
+        tablePos: number;
+        colIndex: number;
+        startX: number;
+        originEdgeX: number;
+        initialWidths: number[];
+        shiftKey: boolean;
+      }
+    | {
+        kind: "row";
+        zone: TableZone;
+        tablePos: number;
+        rowIndex: number;
+        startY: number;
+        originEdgeY: number;
+        initialHeightTwips: number;
+        altKey: boolean;
+      }
+    | {
+        kind: "corner";
+        zone: TableZone;
+        tablePos: number;
+        startX: number;
+        startY: number;
+        initialWidthPx: number;
+        initialHeightPx: number;
+        initialWidths: number[];
+      }
+    | null;
+
+  let tableDrag: TableDrag = null;
+  let tableHoverHit: TableHit | null = null;
+  let tableHoverZone: TableZone | null = null;
+
+  const tableOverlay = new TableCanvasOverlay({
+    scale: () => opts.scale?.() ?? 1,
+    insertColumnAt: (colIndex, tablePos) => {
+      main.editor.commands["insert-column-at"](colIndex, tablePos);
+    },
+    insertRowAt: (rowIndex, tablePos) => {
+      main.editor.commands["insert-row-at"](rowIndex, tablePos);
+    },
+    onCornerDown: (e) => {
+      if (tableHoverZone) {
+        startTableCornerResize(tableHoverZone, e);
+      }
+    },
+  });
+  opts.host.append(tableOverlay.el);
+
+  const startTableColResize = (zone: TableZone, colIndex: number, event: MouseEvent): void => {
+    const tablePos = zone.tablePos;
+    if (tablePos == null) return;
+    const tableNode = main.editor.state.doc.nodeAt(tablePos);
+    if (!tableNode) return;
+    const initialWidths: number[] = [];
+    if (Array.isArray(tableNode.attrs.columnWidths) && tableNode.attrs.columnWidths.length > 0) {
+      initialWidths.push(...(tableNode.attrs.columnWidths as number[]));
+    } else {
+      for (let c = 0; c < zone.colEdges.length - 1; c += 1) {
+        initialWidths.push(Math.round((zone.colEdges[c + 1]! - zone.colEdges[c]!) * PX_TO_TWIPS));
+      }
+    }
+    const scale = opts.scale?.() ?? 1;
+    const originEdgeX = zone.xPx + zone.colEdges[colIndex]!;
+    tableDrag = {
+      kind: "col",
+      zone,
+      tablePos,
+      colIndex,
+      startX: event.clientX,
+      originEdgeX,
+      initialWidths,
+      shiftKey: event.shiftKey,
+    };
+    tableOverlay.showColGuideline(originEdgeX, zone.yPx, zone.heightPx, scale);
+  };
+
+  const startTableRowResize = (zone: TableZone, rowIndex: number, event: MouseEvent): void => {
+    const tablePos = zone.tablePos;
+    if (tablePos == null) return;
+    const tableNode = main.editor.state.doc.nodeAt(tablePos);
+    if (!tableNode || rowIndex - 1 >= tableNode.childCount) return;
+    const rowNode = tableNode.child(rowIndex - 1);
+    const h = rowNode.attrs.height as { value?: number } | null;
+    let initialHeightTwips = 0;
+    if (h && typeof h.value === "number" && h.value > 0) {
+      initialHeightTwips = h.value;
+    } else {
+      initialHeightTwips = Math.round(
+        (zone.rowEdges[rowIndex]! - zone.rowEdges[rowIndex - 1]!) * PX_TO_TWIPS,
+      );
+    }
+    const scale = opts.scale?.() ?? 1;
+    const originEdgeY = zone.yPx + zone.rowEdges[rowIndex]!;
+    tableDrag = {
+      kind: "row",
+      zone,
+      tablePos,
+      rowIndex,
+      startY: event.clientY,
+      originEdgeY,
+      initialHeightTwips,
+      altKey: event.altKey,
+    };
+    tableOverlay.showRowGuideline(zone.xPx, originEdgeY, zone.widthPx, scale);
+  };
+
+  const startTableCornerResize = (zone: TableZone, event: MouseEvent): void => {
+    const tablePos = zone.tablePos;
+    if (tablePos == null) return;
+    const tableNode = main.editor.state.doc.nodeAt(tablePos);
+    if (!tableNode) return;
+    const initialWidths: number[] = [];
+    if (Array.isArray(tableNode.attrs.columnWidths) && tableNode.attrs.columnWidths.length > 0) {
+      initialWidths.push(...(tableNode.attrs.columnWidths as number[]));
+    } else {
+      for (let c = 0; c < zone.colEdges.length - 1; c += 1) {
+        initialWidths.push(Math.round((zone.colEdges[c + 1]! - zone.colEdges[c]!) * PX_TO_TWIPS));
+      }
+    }
+    const scale = opts.scale?.() ?? 1;
+    tableDrag = {
+      kind: "corner",
+      zone,
+      tablePos,
+      startX: event.clientX,
+      startY: event.clientY,
+      initialWidthPx: zone.widthPx,
+      initialHeightPx: zone.heightPx,
+      initialWidths,
+    };
+    tableOverlay.showBoxGuideline(zone.xPx, zone.yPx, zone.widthPx, zone.heightPx, scale);
+  };
+
+  const updateTableDrag = (event: MouseEvent): void => {
+    if (!tableDrag) return;
+    const scale = opts.scale?.() ?? 1;
+    if (tableDrag.kind === "col") {
+      const dxPx = (event.clientX - tableDrag.startX) / scale;
+      const dxTwips = Math.round(dxPx * PX_TO_TWIPS);
+      const nextWidths = calcColumnResize(tableDrag.initialWidths, tableDrag.colIndex, dxTwips, {
+        shiftKey: event.shiftKey || tableDrag.shiftKey,
+      });
+      let curEdgeX = tableDrag.zone.xPx;
+      for (let i = 0; i < tableDrag.colIndex; i += 1) {
+        curEdgeX += (nextWidths[i] ?? 0) * TWIPS_TO_PX;
+      }
+      tableOverlay.showColGuideline(curEdgeX, tableDrag.zone.yPx, tableDrag.zone.heightPx, scale);
+    } else if (tableDrag.kind === "row") {
+      const dyPx = (event.clientY - tableDrag.startY) / scale;
+      const dyTwips = Math.round(dyPx * PX_TO_TWIPS);
+      const res = calcRowResize(tableDrag.initialHeightTwips, dyTwips, {
+        isAlt: event.altKey || tableDrag.altKey,
+      });
+      const newHeightPx = res.value * TWIPS_TO_PX;
+      const curEdgeY =
+        tableDrag.zone.yPx + tableDrag.zone.rowEdges[tableDrag.rowIndex - 1]! + newHeightPx;
+      tableOverlay.showRowGuideline(tableDrag.zone.xPx, curEdgeY, tableDrag.zone.widthPx, scale);
+    } else if (tableDrag.kind === "corner") {
+      const dxPx = (event.clientX - tableDrag.startX) / scale;
+      const dyPx = (event.clientY - tableDrag.startY) / scale;
+      const curWidthPx = Math.max(48, tableDrag.initialWidthPx + dxPx);
+      const curHeightPx = Math.max(24, tableDrag.initialHeightPx + dyPx);
+      tableOverlay.showBoxGuideline(
+        tableDrag.zone.xPx,
+        tableDrag.zone.yPx,
+        curWidthPx,
+        curHeightPx,
+        scale,
+      );
+    }
+  };
+
+  const finishTableDrag = (event: MouseEvent): void => {
+    if (!tableDrag) return;
+    const scale = opts.scale?.() ?? 1;
+    const drag = tableDrag;
+    tableDrag = null;
+    tableOverlay.hideGuideline();
+    tableOverlay.hideBoxGuideline();
+    opts.host.style.cursor = "";
+
+    if (drag.kind === "col") {
+      const dxPx = (event.clientX - drag.startX) / scale;
+      const dxTwips = Math.round(dxPx * PX_TO_TWIPS);
+      const finalWidths = calcColumnResize(drag.initialWidths, drag.colIndex, dxTwips, {
+        shiftKey: event.shiftKey || drag.shiftKey,
+      });
+      main.editor.commands["set-table-column-widths"](finalWidths, drag.tablePos);
+    } else if (drag.kind === "row") {
+      const dyPx = (event.clientY - drag.startY) / scale;
+      const dyTwips = Math.round(dyPx * PX_TO_TWIPS);
+      const res = calcRowResize(drag.initialHeightTwips, dyTwips, {
+        isAlt: event.altKey || drag.altKey,
+      });
+      main.editor.commands["set-table-row-height"](drag.rowIndex - 1, res, drag.tablePos);
+    } else if (drag.kind === "corner") {
+      const dxPx = (event.clientX - drag.startX) / scale;
+      const scaleX = Math.max(0.1, (drag.initialWidthPx + dxPx) / drag.initialWidthPx);
+      const finalWidths = calcTableScale(drag.initialWidths, scaleX);
+      main.editor.commands["set-table-column-widths"](finalWidths, drag.tablePos);
+    }
+  };
+
   /** The hover pass — mousemoves outside a drag resolve against the active
    *  page's table zones (innermost zone wins on nested tables). */
   const hoverTableGrip = (event: MouseEvent): void => {
     grip.kind = null;
     grip.zone = null;
     grip.index = -1;
+    tableHoverHit = null;
+    tableHoverZone = null;
     const s = active();
     if (s.map?.valid && !story) {
       const hit = hitPage(event.clientX, event.clientY);
       // The bars live just outside the zone — widen the zone test to the
       // grip window (the strips reach ~14px past the table's edges).
-      const zone = hit
-        ? s.map.tableZoneAt(story ? 0 : hit.page, hit.lx, hit.ly, GRIP_WINDOW + 2)
-        : null;
+      const zone = hit ? s.map.tableZoneAt(story ? 0 : hit.page, hit.lx, hit.ly, 24) : null;
       if (hit && zone) {
+        const frame = opts.pageHost?.(framePage(s, zone.page)) ?? null;
+        if (frame) tableOverlay.attachTo(frame);
+        const scale = opts.scale?.() ?? 1;
+
+        // Check table interactive elements (borders, corner, quick-insert)
+        const hitElem = hitTableElements(zone, hit.lx, hit.ly);
+        if (hitElem) {
+          tableHoverHit = hitElem;
+          tableHoverZone = zone;
+          if (hitElem.kind === "col-border") {
+            opts.host.style.cursor = "col-resize";
+            tableOverlay.showCorner(zone, scale);
+            tableOverlay.hideQuickCol();
+            tableOverlay.hideQuickRow();
+          } else if (hitElem.kind === "row-border") {
+            opts.host.style.cursor = "row-resize";
+            tableOverlay.showCorner(zone, scale);
+            tableOverlay.hideQuickCol();
+            tableOverlay.hideQuickRow();
+          } else if (hitElem.kind === "corner-handle") {
+            opts.host.style.cursor = "nwse-resize";
+            tableOverlay.showCorner(zone, scale);
+            tableOverlay.hideQuickCol();
+            tableOverlay.hideQuickRow();
+          } else if (hitElem.kind === "quick-col") {
+            opts.host.style.cursor = "default";
+            tableOverlay.showQuickCol(zone, hitElem.colIndex, scale);
+            tableOverlay.hideQuickRow();
+            tableOverlay.showCorner(zone, scale);
+          } else if (hitElem.kind === "quick-row") {
+            opts.host.style.cursor = "default";
+            tableOverlay.showQuickRow(zone, hitElem.rowIndex, scale);
+            tableOverlay.hideQuickCol();
+            tableOverlay.showCorner(zone, scale);
+          }
+        } else {
+          if (
+            opts.host.style.cursor === "col-resize" ||
+            opts.host.style.cursor === "row-resize" ||
+            opts.host.style.cursor === "nwse-resize"
+          ) {
+            opts.host.style.cursor = "";
+          }
+          tableOverlay.hideQuickCol();
+          tableOverlay.hideQuickRow();
+          const inTable =
+            hit.lx >= zone.xPx &&
+            hit.lx <= zone.xPx + zone.widthPx &&
+            hit.ly >= zone.yPx &&
+            hit.ly <= zone.yPx + zone.heightPx;
+          if (inTable) {
+            tableOverlay.showCorner(zone, scale);
+          } else {
+            tableOverlay.hideCorner();
+          }
+        }
+
         const lx = hit.lx - zone.xPx;
         const ly = hit.ly - zone.yPx;
         // The corner square wins the top-left overlap with the row strip.
@@ -1039,7 +1314,18 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
           // but only the corner window itself clicks it; here a click edits.
           grip.zone = zone;
         }
+      } else {
+        tableOverlay.hideAll();
+        if (
+          opts.host.style.cursor === "col-resize" ||
+          opts.host.style.cursor === "row-resize" ||
+          opts.host.style.cursor === "nwse-resize"
+        ) {
+          opts.host.style.cursor = "";
+        }
       }
+    } else {
+      tableOverlay.hideAll();
     }
     placeGrip();
   };
@@ -1183,9 +1469,27 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     posAtClient: (x, y) => posAtClient(x, y),
     linkAt,
   });
-  opts.host.addEventListener("mouseleave", linkHover.hide);
+  opts.host.addEventListener("mouseleave", () => {
+    linkHover.hide();
+    if (!tableDrag) {
+      tableOverlay.hideQuickCol();
+      tableOverlay.hideQuickRow();
+      tableHoverHit = null;
+      if (
+        opts.host.style.cursor === "col-resize" ||
+        opts.host.style.cursor === "row-resize" ||
+        opts.host.style.cursor === "nwse-resize"
+      ) {
+        opts.host.style.cursor = "";
+      }
+    }
+  });
 
   const onMouseMove = (event: MouseEvent): void => {
+    if (tableDrag != null) {
+      updateTableDrag(event);
+      return;
+    }
     if (dragAnchor == null) {
       hoverTableGrip(event);
       linkHover.onMove(event);
@@ -1207,14 +1511,26 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     const head = posAtClient(event.clientX, event.clientY, true);
     if (head != null) setDragSelection(dragAnchor, head);
   };
-  const onMouseUp = (): void => {
+  const onMouseUp = (event: MouseEvent): void => {
+    if (tableDrag != null) {
+      finishTableDrag(event);
+    }
     dragAnchor = null;
     dragMoved = false;
     dragStart = null;
     stopDragAutoScroll();
   };
+  const onDocKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === "Escape" && tableDrag) {
+      tableDrag = null;
+      tableOverlay.hideGuideline();
+      tableOverlay.hideBoxGuideline();
+      opts.host.style.cursor = "";
+    }
+  };
   document.addEventListener("mousemove", onMouseMove);
   document.addEventListener("mouseup", onMouseUp);
+  document.addEventListener("keydown", onDocKeyDown);
 
   /** Enter a furniture story: a second viewless editor over the slot's
    *  JSON, a caret map over its laid stack (wrapped as one pseudo page
@@ -1385,6 +1701,20 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
     // a click that lands without a prior move reaching the strip.
     if (!story) {
       hoverTableGrip(event);
+      if (tableHoverHit && tableHoverZone) {
+        if (tableHoverHit.kind === "col-border") {
+          startTableColResize(tableHoverZone, tableHoverHit.colIndex, event);
+          return;
+        }
+        if (tableHoverHit.kind === "row-border") {
+          startTableRowResize(tableHoverZone, tableHoverHit.rowIndex, event);
+          return;
+        }
+        if (tableHoverHit.kind === "corner-handle") {
+          startTableCornerResize(tableHoverZone, event);
+          return;
+        }
+      }
       if (grip.kind) {
         applyGrip();
         ta.focus();
@@ -2451,6 +2781,8 @@ export function mountEditBridge(opts: EditBridgeOptions): EditBridge {
       opts.host.removeEventListener("mousedown", takeFocus);
       document.removeEventListener("mousemove", onMouseMove);
       document.removeEventListener("mouseup", onMouseUp);
+      document.removeEventListener("keydown", onDocKeyDown);
+      tableOverlay.destroy();
       drawingOverlay.hide();
       drawingOverlay.el.remove();
       for (const el of selectionLayer) el.remove();

--- a/packages/editor/src/document/canvas/table-geometry.spec.ts
+++ b/packages/editor/src/document/canvas/table-geometry.spec.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+import type { TableZone } from "./caret-map";
+import {
+  calcColumnResize,
+  calcRowResize,
+  calcTableScale,
+  hitTableElements,
+  MIN_COL_TWIPS,
+  MIN_ROW_TWIPS,
+} from "./table-geometry";
+
+describe("table-geometry", () => {
+  const sampleZone: TableZone = {
+    page: 0,
+    xPx: 100,
+    yPx: 150,
+    widthPx: 300,
+    heightPx: 120,
+    colEdges: [0, 100, 200, 300], // 3 columns
+    rowEdges: [0, 40, 80, 120], // 3 rows
+  };
+
+  describe("hitTableElements", () => {
+    it("detects bottom-right corner resize handle", () => {
+      // Corner is at (xPx + widthPx, yPx + heightPx) = (400, 270)
+      const hit = hitTableElements(sampleZone, 400, 270);
+      expect(hit).toEqual({ kind: "corner-handle" });
+
+      const nearHit = hitTableElements(sampleZone, 396, 268);
+      expect(nearHit).toEqual({ kind: "corner-handle" });
+    });
+
+    it("detects interior column border hit", () => {
+      // Border 1 is at x = 100 + 100 = 200
+      const hit = hitTableElements(sampleZone, 201, 180);
+      expect(hit).toEqual({ kind: "col-border", colIndex: 1 });
+
+      // Border 2 is at x = 100 + 200 = 300
+      const hit2 = hitTableElements(sampleZone, 299, 200);
+      expect(hit2).toEqual({ kind: "col-border", colIndex: 2 });
+    });
+
+    it("detects rightmost column border hit", () => {
+      // Border 3 is at x = 100 + 300 = 400, mid-height y = 200
+      const hit = hitTableElements(sampleZone, 400, 200);
+      expect(hit).toEqual({ kind: "col-border", colIndex: 3 });
+    });
+
+    it("detects interior row border hit", () => {
+      // Row border 1 is at y = 150 + 40 = 190
+      const hit = hitTableElements(sampleZone, 150, 191);
+      expect(hit).toEqual({ kind: "row-border", rowIndex: 1 });
+
+      // Row border 2 is at y = 150 + 80 = 230
+      const hit2 = hitTableElements(sampleZone, 250, 230);
+      expect(hit2).toEqual({ kind: "row-border", rowIndex: 2 });
+    });
+
+    it("detects quick-insert column button zone", () => {
+      // Border 1 top is at x = 200, y = 150. Above top edge: y = 140
+      const hit = hitTableElements(sampleZone, 200, 140);
+      expect(hit).toEqual({ kind: "quick-col", colIndex: 1 });
+    });
+
+    it("detects quick-insert row button zone", () => {
+      // Border 1 left is at x = 100, y = 190. Left of left edge: x = 90
+      const hit = hitTableElements(sampleZone, 90, 190);
+      expect(hit).toEqual({ kind: "quick-row", rowIndex: 1 });
+    });
+
+    it("returns null for points in the middle of cells", () => {
+      const hit = hitTableElements(sampleZone, 150, 170);
+      expect(hit).toBeNull();
+    });
+  });
+
+  describe("calcColumnResize", () => {
+    it("redistributes width between two interior columns without changing total width", () => {
+      const initial = [2000, 2000, 2000];
+      // Drag border 1 (between col 0 and col 1) rightward by +500 twips
+      const next = calcColumnResize(initial, 1, 500);
+      expect(next).toEqual([2500, 1500, 2000]);
+      expect(next.reduce((a, b) => a + b, 0)).toBe(6000);
+    });
+
+    it("clamps column width so neither column drops below MIN_COL_TWIPS", () => {
+      const initial = [2000, 2000, 2000];
+      // Try to drag border 1 rightward by +3000 twips (which would make col 1 negative)
+      const next = calcColumnResize(initial, 1, 3000);
+      expect(next[1]).toBe(MIN_COL_TWIPS);
+      expect(next[0]).toBe(4000 - MIN_COL_TWIPS);
+      expect(next[2]).toBe(2000);
+    });
+
+    it("resizes last column when dragging outer right border", () => {
+      const initial = [2000, 2000, 2000];
+      // Drag border 3 (outer right) rightward by +800 twips
+      const next = calcColumnResize(initial, 3, 800);
+      expect(next).toEqual([2000, 2000, 2800]);
+    });
+
+    it("shifts subsequent columns when shiftKey is held", () => {
+      const initial = [2000, 2000, 2000];
+      // Drag border 1 rightward by +400 twips with Shift
+      const next = calcColumnResize(initial, 1, 400, { shiftKey: true });
+      expect(next).toEqual([2400, 2000, 2000]);
+    });
+  });
+
+  describe("calcRowResize", () => {
+    it("returns atLeast rule by default with updated value", () => {
+      const res = calcRowResize(400, 200);
+      expect(res).toEqual({ rule: "atLeast", value: 600 });
+    });
+
+    it("returns exact rule when isAlt is true", () => {
+      const res = calcRowResize(400, 150, { isAlt: true });
+      expect(res).toEqual({ rule: "exact", value: 550 });
+    });
+
+    it("clamps minimum row height", () => {
+      const res = calcRowResize(400, -800);
+      expect(res.value).toBe(MIN_ROW_TWIPS);
+    });
+  });
+
+  describe("calcTableScale", () => {
+    it("scales all columns proportionally", () => {
+      const initial = [1000, 2000, 3000];
+      const scaled = calcTableScale(initial, 1.5);
+      expect(scaled).toEqual([1500, 3000, 4500]);
+    });
+
+    it("clamps each column to minWidth", () => {
+      const initial = [1000, 2000];
+      const scaled = calcTableScale(initial, 0.1);
+      expect(scaled).toEqual([MIN_COL_TWIPS, MIN_COL_TWIPS]);
+    });
+  });
+});

--- a/packages/editor/src/document/canvas/table-geometry.ts
+++ b/packages/editor/src/document/canvas/table-geometry.ts
@@ -1,0 +1,177 @@
+/**
+ * Table interaction geometry — the math behind canvas table resizing,
+ * border hit detection, and quick-insert controls. Pure functions on plain
+ * coordinates and width/height arrays.
+ */
+
+import type { TableZone } from "./caret-map";
+
+/** 1 px = 15 twips (96 DPI standard: 1440 twips / 96 px = 15 twips/px). */
+export const PX_TO_TWIPS = 15;
+export const TWIPS_TO_PX = 1 / 15;
+
+/** Minimum column width in twips: 0.5 inch (720 twips = 48 px). */
+export const MIN_COL_TWIPS = 720;
+
+/** Minimum row height in twips: 9 pt (180 twips = 12 px). */
+export const MIN_ROW_TWIPS = 180;
+
+/** Hit-test margin for table borders in page px. */
+export const BORDER_GRAB_PX = 4;
+
+/** Hit-test radius for the bottom-right corner resize handle in page px. */
+export const CORNER_HANDLE_RADIUS_PX = 7;
+
+export type TableHit =
+  | { kind: "col-border"; colIndex: number }
+  | { kind: "row-border"; rowIndex: number }
+  | { kind: "corner-handle" }
+  | { kind: "quick-col"; colIndex: number }
+  | { kind: "quick-row"; rowIndex: number };
+
+/**
+ * Hit-test a table zone against a page-local coordinate (lx, ly).
+ * Returns the hit kind (col-border, row-border, corner-handle, or quick-insert)
+ * or null if the pointer is not over any interactive handle.
+ */
+export function hitTableElements(zone: TableZone, lx: number, ly: number): TableHit | null {
+  const tx = lx - zone.xPx;
+  const ty = ly - zone.yPx;
+
+  // 1. Bottom-right corner resize handle
+  const distCornerX = Math.abs(tx - zone.widthPx);
+  const distCornerY = Math.abs(ty - zone.heightPx);
+  if (distCornerX <= CORNER_HANDLE_RADIUS_PX && distCornerY <= CORNER_HANDLE_RADIUS_PX) {
+    return { kind: "corner-handle" };
+  }
+
+  // 2. Quick-insert column (+) button area: hovering just above the table top edge
+  if (ty >= -20 && ty <= 2) {
+    for (let i = 1; i < zone.colEdges.length; i += 1) {
+      if (Math.abs(tx - zone.colEdges[i]!) <= 10) {
+        return { kind: "quick-col", colIndex: i };
+      }
+    }
+  }
+
+  // 3. Quick-insert row (+) button area: hovering just to the left of the table
+  if (tx >= -20 && tx <= 2) {
+    for (let r = 1; r < zone.rowEdges.length; r += 1) {
+      if (Math.abs(ty - zone.rowEdges[r]!) <= 10) {
+        return { kind: "quick-row", rowIndex: r };
+      }
+    }
+  }
+
+  // 4. Column borders (vertical lines): index 1 through colEdges.length - 1
+  // (Interior borders + right border). Edge index `i` sits between col `i - 1` and col `i`.
+  if (ty >= -BORDER_GRAB_PX && ty <= zone.heightPx + BORDER_GRAB_PX) {
+    for (let i = 1; i < zone.colEdges.length; i += 1) {
+      if (Math.abs(tx - zone.colEdges[i]!) <= BORDER_GRAB_PX) {
+        return { kind: "col-border", colIndex: i };
+      }
+    }
+  }
+
+  // 5. Row borders (horizontal lines): index 1 through rowEdges.length - 1
+  // (Bottom border of row `r - 1`).
+  if (tx >= -BORDER_GRAB_PX && tx <= zone.widthPx + BORDER_GRAB_PX) {
+    for (let r = 1; r < zone.rowEdges.length; r += 1) {
+      if (Math.abs(ty - zone.rowEdges[r]!) <= BORDER_GRAB_PX) {
+        return { kind: "row-border", rowIndex: r };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Calculates new column widths (in twips) when dragging a column border.
+ *
+ * @param initialWidths Original column widths array (twips).
+ * @param colIndex 1-based border index. 1 = between col 0 and 1; N = right border.
+ * @param dxTwips Mouse movement delta in twips.
+ * @param options Shift key and minimum width configuration.
+ */
+export function calcColumnResize(
+  initialWidths: readonly number[],
+  colIndex: number,
+  dxTwips: number,
+  options: { shiftKey?: boolean; minWidthTwips?: number } = {},
+): number[] {
+  const minWidth = options.minWidthTwips ?? MIN_COL_TWIPS;
+  const nCols = initialWidths.length;
+  if (nCols === 0 || colIndex < 1 || colIndex > nCols) {
+    return [...initialWidths];
+  }
+
+  const widths = [...initialWidths];
+
+  // Case A: Rightmost border (changes table total width)
+  if (colIndex === nCols) {
+    const lastIdx = nCols - 1;
+    widths[lastIdx] = Math.max(minWidth, (widths[lastIdx] ?? 0) + dxTwips);
+    return widths;
+  }
+
+  // Case B: Shift pressed on interior border — shifts all subsequent columns rightward
+  if (options.shiftKey) {
+    const leftIdx = colIndex - 1;
+    widths[leftIdx] = Math.max(minWidth, (widths[leftIdx] ?? 0) + dxTwips);
+    return widths;
+  }
+
+  // Case C: Standard Word drag on interior border — redistributes width between col i-1 and col i
+  const leftIdx = colIndex - 1;
+  const rightIdx = colIndex;
+  const wLeft = widths[leftIdx] ?? 0;
+  const wRight = widths[rightIdx] ?? 0;
+  const sum = wLeft + wRight;
+
+  const targetLeft = wLeft + dxTwips;
+  const clampedLeft = Math.max(minWidth, Math.min(sum - minWidth, targetLeft));
+  const clampedRight = sum - clampedLeft;
+
+  widths[leftIdx] = clampedLeft;
+  widths[rightIdx] = clampedRight;
+  return widths;
+}
+
+/**
+ * Calculates new row height when dragging a row's bottom border.
+ *
+ * @param initialHeightTwips Initial height of the row in twips (or natural height).
+ * @param dyTwips Vertical drag delta in twips.
+ * @param options Modifier flags (e.g. Alt key for "exact" rule) and minimum height.
+ */
+export function calcRowResize(
+  initialHeightTwips: number,
+  dyTwips: number,
+  options: { isAlt?: boolean; minHeightTwips?: number } = {},
+): { rule: "atLeast" | "exact"; value: number } {
+  const minHeight = options.minHeightTwips ?? MIN_ROW_TWIPS;
+  const target = Math.max(minHeight, initialHeightTwips + dyTwips);
+  return {
+    rule: options.isAlt ? "exact" : "atLeast",
+    value: Math.round(target),
+  };
+}
+
+/**
+ * Scales all column widths proportionally when dragging the bottom-right corner handle.
+ *
+ * @param initialWidths Original column widths array (twips).
+ * @param scaleX Horizontal scaling factor (> 0).
+ * @param minWidthTwips Minimum column width.
+ */
+export function calcTableScale(
+  initialWidths: readonly number[],
+  scaleX: number,
+  minWidthTwips = MIN_COL_TWIPS,
+): number[] {
+  if (initialWidths.length === 0 || !Number.isFinite(scaleX) || scaleX <= 0) {
+    return [...initialWidths];
+  }
+  return initialWidths.map((w) => Math.max(minWidthTwips, Math.round(w * scaleX)));
+}

--- a/packages/editor/src/document/canvas/table-overlay.spec.ts
+++ b/packages/editor/src/document/canvas/table-overlay.spec.ts
@@ -1,0 +1,186 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from "vitest";
+
+import type { TableZone } from "./caret-map";
+import { TableCanvasOverlay } from "./table-overlay";
+
+describe("TableCanvasOverlay", () => {
+  const mockZone: TableZone = {
+    page: 0,
+    xPx: 100,
+    yPx: 50,
+    widthPx: 300,
+    heightPx: 150,
+    colEdges: [0, 100, 200, 300],
+    rowEdges: [0, 50, 100, 150],
+    tablePos: 12,
+  };
+
+  it("creates overlay elements with correct default styles and attributes", () => {
+    const callbacks = {
+      scale: () => 1,
+      insertColumnAt: vi.fn(),
+      insertRowAt: vi.fn(),
+    };
+    const overlay = new TableCanvasOverlay(callbacks);
+
+    expect(overlay.el.hasAttribute("data-docen-overlay")).toBe(true);
+    expect(overlay.guideline.hasAttribute("data-docen-overlay")).toBe(true);
+    expect(overlay.cornerHandle.hasAttribute("data-docen-overlay")).toBe(true);
+    expect(overlay.quickColBtn.hasAttribute("data-docen-overlay")).toBe(true);
+    expect(overlay.quickRowBtn.hasAttribute("data-docen-overlay")).toBe(true);
+
+    expect(overlay.guideline.style.display).toBe("none");
+    expect(overlay.cornerHandle.style.display).toBe("none");
+    expect(overlay.quickColBtn.style.display).toBe("none");
+    expect(overlay.quickRowBtn.style.display).toBe("none");
+  });
+
+  it("attaches to container frame", () => {
+    const frame = document.createElement("div");
+    const overlay = new TableCanvasOverlay({
+      scale: () => 1,
+      insertColumnAt: vi.fn(),
+      insertRowAt: vi.fn(),
+    });
+
+    overlay.attachTo(frame);
+    expect(overlay.el.parentElement).toBe(frame);
+  });
+
+  it("positions and displays corner handle correctly", () => {
+    const overlay = new TableCanvasOverlay({
+      scale: () => 2,
+      insertColumnAt: vi.fn(),
+      insertRowAt: vi.fn(),
+    });
+
+    overlay.showCorner(mockZone, 2);
+    // (xPx + widthPx) * scale - 4 = (100 + 300) * 2 - 4 = 796px
+    // (yPx + heightPx) * scale - 4 = (50 + 150) * 2 - 4 = 396px
+    expect(overlay.cornerHandle.style.left).toBe("796px");
+    expect(overlay.cornerHandle.style.top).toBe("396px");
+    expect(overlay.cornerHandle.style.display).toBe("block");
+
+    overlay.hideCorner();
+    expect(overlay.cornerHandle.style.display).toBe("none");
+  });
+
+  it("dispatches onCornerDown callback when corner handle is clicked", () => {
+    const onCornerDown = vi.fn();
+    const overlay = new TableCanvasOverlay({
+      scale: () => 1,
+      insertColumnAt: vi.fn(),
+      insertRowAt: vi.fn(),
+      onCornerDown,
+    });
+
+    const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+    overlay.cornerHandle.dispatchEvent(event);
+
+    expect(onCornerDown).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("positions quick column insert button and triggers insertColumnAt on mousedown", () => {
+    const insertColumnAt = vi.fn();
+    const overlay = new TableCanvasOverlay({
+      scale: () => 1,
+      insertColumnAt,
+      insertRowAt: vi.fn(),
+    });
+
+    overlay.showQuickCol(mockZone, 1, 1);
+    // borderX = 100 + 100 = 200. left = 200 * 1 - 8 = 192px. top = 50 * 1 - 18 = 32px.
+    expect(overlay.quickColBtn.style.left).toBe("192px");
+    expect(overlay.quickColBtn.style.top).toBe("32px");
+    expect(overlay.quickColBtn.style.display).toBe("flex");
+
+    const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+    overlay.quickColBtn.dispatchEvent(event);
+
+    expect(insertColumnAt).toHaveBeenCalledWith(1, 12);
+  });
+
+  it("positions quick row insert button and triggers insertRowAt on mousedown", () => {
+    const insertRowAt = vi.fn();
+    const overlay = new TableCanvasOverlay({
+      scale: () => 1,
+      insertColumnAt: vi.fn(),
+      insertRowAt,
+    });
+
+    overlay.showQuickRow(mockZone, 2, 1);
+    // left = 100 * 1 - 18 = 82px. borderY = 50 + 100 = 150. top = 150 * 1 - 8 = 142px.
+    expect(overlay.quickRowBtn.style.left).toBe("82px");
+    expect(overlay.quickRowBtn.style.top).toBe("142px");
+    expect(overlay.quickRowBtn.style.display).toBe("flex");
+
+    const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+    overlay.quickRowBtn.dispatchEvent(event);
+
+    expect(insertRowAt).toHaveBeenCalledWith(2, 12);
+  });
+
+  it("shows column and row guidelines accurately", () => {
+    const overlay = new TableCanvasOverlay({
+      scale: () => 1,
+      insertColumnAt: vi.fn(),
+      insertRowAt: vi.fn(),
+    });
+
+    overlay.showColGuideline(250, 50, 150, 1);
+    expect(overlay.guideline.style.left).toBe("249px");
+    expect(overlay.guideline.style.top).toBe("50px");
+    expect(overlay.guideline.style.width).toBe("2px");
+    expect(overlay.guideline.style.height).toBe("150px");
+    expect(overlay.guideline.style.display).toBe("block");
+
+    overlay.hideGuideline();
+    expect(overlay.guideline.style.display).toBe("none");
+
+    overlay.showRowGuideline(100, 120, 300, 1);
+    expect(overlay.guideline.style.left).toBe("100px");
+    expect(overlay.guideline.style.top).toBe("119px");
+    expect(overlay.guideline.style.width).toBe("300px");
+    expect(overlay.guideline.style.height).toBe("2px");
+    expect(overlay.guideline.style.display).toBe("block");
+  });
+
+  it("shows table bounding box guideline for corner scaling", () => {
+    const overlay = new TableCanvasOverlay({
+      scale: () => 1,
+      insertColumnAt: vi.fn(),
+      insertRowAt: vi.fn(),
+    });
+
+    overlay.showBoxGuideline(100, 50, 320, 160, 1);
+    expect(overlay.guidelineBox.style.left).toBe("100px");
+    expect(overlay.guidelineBox.style.top).toBe("50px");
+    expect(overlay.guidelineBox.style.width).toBe("320px");
+    expect(overlay.guidelineBox.style.height).toBe("160px");
+    expect(overlay.guidelineBox.style.display).toBe("block");
+
+    overlay.hideBoxGuideline();
+    expect(overlay.guidelineBox.style.display).toBe("none");
+  });
+
+  it("hides all overlays and removes element on destroy", () => {
+    const frame = document.createElement("div");
+    const overlay = new TableCanvasOverlay({
+      scale: () => 1,
+      insertColumnAt: vi.fn(),
+      insertRowAt: vi.fn(),
+    });
+    overlay.attachTo(frame);
+    overlay.showCorner(mockZone, 1);
+    overlay.showQuickCol(mockZone, 1, 1);
+
+    expect(frame.contains(overlay.el)).toBe(true);
+
+    overlay.destroy();
+    expect(frame.contains(overlay.el)).toBe(false);
+    expect(overlay.cornerHandle.style.display).toBe("none");
+    expect(overlay.quickColBtn.style.display).toBe("none");
+  });
+});

--- a/packages/editor/src/document/canvas/table-overlay.ts
+++ b/packages/editor/src/document/canvas/table-overlay.ts
@@ -1,0 +1,353 @@
+/**
+ * Canvas table overlay — Word's interactive table controls on the canvas:
+ * 1. Guideline: visual line indicating the column or row boundary being dragged.
+ * 2. Corner handle: bottom-right square handle to resize the table proportionally.
+ * 3. Quick-Insert buttons: floating (+) buttons on column and row boundaries.
+ */
+
+import type { TableZone } from "./caret-map";
+
+export interface TableOverlayCallbacks {
+  scale(): number;
+  insertColumnAt(colIndex: number, tablePos: number): void;
+  insertRowAt(rowIndex: number, tablePos: number): void;
+  onCornerDown?(e: MouseEvent): void;
+}
+
+export class TableCanvasOverlay {
+  readonly el: HTMLDivElement;
+  readonly guideline: HTMLDivElement;
+  readonly guidelineBox: HTMLDivElement;
+  readonly cornerHandle: HTMLDivElement;
+  readonly quickColBtn: HTMLDivElement;
+  readonly quickRowBtn: HTMLDivElement;
+  readonly quickGuide: HTMLDivElement;
+
+  #callbacks: TableOverlayCallbacks;
+  #currentZone: TableZone | null = null;
+  #quickColIndex = -1;
+  #quickRowIndex = -1;
+
+  constructor(callbacks: TableOverlayCallbacks) {
+    this.#callbacks = callbacks;
+
+    this.el = document.createElement("div");
+    this.el.setAttribute("data-docen-overlay", "");
+    Object.assign(this.el.style, {
+      position: "absolute",
+      inset: "0",
+      pointerEvents: "none",
+      zIndex: "6",
+    } satisfies Partial<CSSStyleDeclaration>);
+
+    // 1. Guideline for single column or row border dragging
+    this.guideline = document.createElement("div");
+    this.guideline.setAttribute("data-docen-overlay", "");
+    Object.assign(this.guideline.style, {
+      position: "absolute",
+      display: "none",
+      pointerEvents: "none",
+      backgroundColor: "#2b7cd3",
+      boxShadow: "0 0 3px rgba(43, 124, 211, 0.8)",
+      zIndex: "10",
+    } satisfies Partial<CSSStyleDeclaration>);
+    this.el.append(this.guideline);
+
+    // 2. Guideline bounding box for whole-table corner resizing
+    this.guidelineBox = document.createElement("div");
+    this.guidelineBox.setAttribute("data-docen-overlay", "");
+    Object.assign(this.guidelineBox.style, {
+      position: "absolute",
+      display: "none",
+      pointerEvents: "none",
+      border: "1.5px dashed #2b7cd3",
+      boxSizing: "border-box",
+      zIndex: "10",
+    } satisfies Partial<CSSStyleDeclaration>);
+    this.el.append(this.guidelineBox);
+
+    // 3. Bottom-right corner resize handle
+    this.cornerHandle = document.createElement("div");
+    this.cornerHandle.setAttribute("data-docen-overlay", "");
+    this.cornerHandle.title = "Resize table";
+    Object.assign(this.cornerHandle.style, {
+      position: "absolute",
+      width: "8px",
+      height: "8px",
+      backgroundColor: "#ffffff",
+      border: "1.5px solid #2b7cd3",
+      borderRadius: "1px",
+      boxSizing: "border-box",
+      cursor: "nwse-resize",
+      pointerEvents: "auto",
+      display: "none",
+      zIndex: "8",
+    } satisfies Partial<CSSStyleDeclaration>);
+    this.cornerHandle.addEventListener("mouseenter", () => {
+      this.cornerHandle.style.backgroundColor = "#e8f1fa";
+    });
+    this.cornerHandle.addEventListener("mouseleave", () => {
+      this.cornerHandle.style.backgroundColor = "#ffffff";
+    });
+    this.cornerHandle.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.#callbacks.onCornerDown?.(e);
+    });
+    this.el.append(this.cornerHandle);
+
+    // 4. Quick insert preview guide (dashed line)
+    this.quickGuide = document.createElement("div");
+    this.quickGuide.setAttribute("data-docen-overlay", "");
+    Object.assign(this.quickGuide.style, {
+      position: "absolute",
+      display: "none",
+      pointerEvents: "none",
+      zIndex: "7",
+    } satisfies Partial<CSSStyleDeclaration>);
+    this.el.append(this.quickGuide);
+
+    // 5. Quick-insert column button (+)
+    this.quickColBtn = document.createElement("div");
+    this.quickColBtn.setAttribute("data-docen-overlay", "");
+    this.quickColBtn.title = "Insert column";
+    Object.assign(this.quickColBtn.style, {
+      position: "absolute",
+      width: "16px",
+      height: "16px",
+      borderRadius: "50%",
+      backgroundColor: "#ffffff",
+      border: "1.5px solid #2b7cd3",
+      color: "#2b7cd3",
+      display: "none",
+      alignItems: "center",
+      justifyContent: "center",
+      cursor: "pointer",
+      pointerEvents: "auto",
+      boxShadow: "0 1px 4px rgba(0, 0, 0, 0.2)",
+      zIndex: "9",
+      fontSize: "12px",
+      lineHeight: "12px",
+      userSelect: "none",
+    } satisfies Partial<CSSStyleDeclaration>);
+    this.quickColBtn.innerHTML =
+      '<svg width="10" height="10" viewBox="0 0 10 10" style="display:block;"><path d="M5 1v8M1 5h8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>';
+    this.quickColBtn.addEventListener("mouseenter", () => {
+      this.quickColBtn.style.backgroundColor = "#2b7cd3";
+      this.quickColBtn.style.color = "#ffffff";
+      this.#showColGuide();
+    });
+    this.quickColBtn.addEventListener("mouseleave", () => {
+      this.quickColBtn.style.backgroundColor = "#ffffff";
+      this.quickColBtn.style.color = "#2b7cd3";
+      this.quickGuide.style.display = "none";
+    });
+    this.quickColBtn.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (this.#quickColIndex > 0 && this.#currentZone?.tablePos != null) {
+        this.#callbacks.insertColumnAt(this.#quickColIndex, this.#currentZone.tablePos);
+      }
+    });
+    this.el.append(this.quickColBtn);
+
+    // 6. Quick-insert row button (+)
+    this.quickRowBtn = document.createElement("div");
+    this.quickRowBtn.setAttribute("data-docen-overlay", "");
+    this.quickRowBtn.title = "Insert row";
+    Object.assign(this.quickRowBtn.style, {
+      position: "absolute",
+      width: "16px",
+      height: "16px",
+      borderRadius: "50%",
+      backgroundColor: "#ffffff",
+      border: "1.5px solid #2b7cd3",
+      color: "#2b7cd3",
+      display: "none",
+      alignItems: "center",
+      justifyContent: "center",
+      cursor: "pointer",
+      pointerEvents: "auto",
+      boxShadow: "0 1px 4px rgba(0, 0, 0, 0.2)",
+      zIndex: "9",
+      fontSize: "12px",
+      lineHeight: "12px",
+      userSelect: "none",
+    } satisfies Partial<CSSStyleDeclaration>);
+    this.quickRowBtn.innerHTML =
+      '<svg width="10" height="10" viewBox="0 0 10 10" style="display:block;"><path d="M5 1v8M1 5h8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>';
+    this.quickRowBtn.addEventListener("mouseenter", () => {
+      this.quickRowBtn.style.backgroundColor = "#2b7cd3";
+      this.quickRowBtn.style.color = "#ffffff";
+      this.#showRowGuide();
+    });
+    this.quickRowBtn.addEventListener("mouseleave", () => {
+      this.quickRowBtn.style.backgroundColor = "#ffffff";
+      this.quickRowBtn.style.color = "#2b7cd3";
+      this.quickGuide.style.display = "none";
+    });
+    this.quickRowBtn.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (this.#quickRowIndex > 0 && this.#currentZone?.tablePos != null) {
+        this.#callbacks.insertRowAt(this.#quickRowIndex, this.#currentZone.tablePos);
+      }
+    });
+    this.el.append(this.quickRowBtn);
+  }
+
+  /** Ensure the overlay element is attached to the target page frame container. */
+  attachTo(frame: HTMLElement): void {
+    if (this.el.parentElement !== frame) {
+      frame.append(this.el);
+    }
+  }
+
+  /** Show and place the corner resize handle at the table's bottom-right corner. */
+  showCorner(zone: TableZone, scale: number): void {
+    this.#currentZone = zone;
+    const left = (zone.xPx + zone.widthPx) * scale - 4;
+    const top = (zone.yPx + zone.heightPx) * scale - 4;
+    this.cornerHandle.style.left = `${left}px`;
+    this.cornerHandle.style.top = `${top}px`;
+    this.cornerHandle.style.display = "block";
+  }
+
+  /** Hide the corner handle. */
+  hideCorner(): void {
+    this.cornerHandle.style.display = "none";
+  }
+
+  /** Show the quick-insert column (+) button at the top boundary. */
+  showQuickCol(zone: TableZone, colIndex: number, scale: number): void {
+    this.#currentZone = zone;
+    this.#quickColIndex = colIndex;
+    const borderX = zone.xPx + zone.colEdges[colIndex]!;
+    this.quickColBtn.style.left = `${borderX * scale - 8}px`;
+    this.quickColBtn.style.top = `${zone.yPx * scale - 18}px`;
+    this.quickColBtn.style.display = "flex";
+  }
+
+  /** Hide the quick-insert column button and guide. */
+  hideQuickCol(): void {
+    this.quickColBtn.style.display = "none";
+    if (this.#quickColIndex > 0) {
+      this.quickGuide.style.display = "none";
+      this.#quickColIndex = -1;
+    }
+  }
+
+  /** Show the quick-insert row (+) button at the left boundary. */
+  showQuickRow(zone: TableZone, rowIndex: number, scale: number): void {
+    this.#currentZone = zone;
+    this.#quickRowIndex = rowIndex;
+    const borderY = zone.yPx + zone.rowEdges[rowIndex]!;
+    this.quickRowBtn.style.left = `${zone.xPx * scale - 18}px`;
+    this.quickRowBtn.style.top = `${borderY * scale - 8}px`;
+    this.quickRowBtn.style.display = "flex";
+  }
+
+  /** Hide the quick-insert row button and guide. */
+  hideQuickRow(): void {
+    this.quickRowBtn.style.display = "none";
+    if (this.#quickRowIndex > 0) {
+      this.quickGuide.style.display = "none";
+      this.#quickRowIndex = -1;
+    }
+  }
+
+  #showColGuide(): void {
+    if (!this.#currentZone || this.#quickColIndex <= 0) return;
+    const scale = this.#callbacks.scale();
+    const borderX = this.#currentZone.xPx + this.#currentZone.colEdges[this.#quickColIndex]!;
+    Object.assign(this.quickGuide.style, {
+      left: `${borderX * scale}px`,
+      top: `${this.#currentZone.yPx * scale}px`,
+      width: "1px",
+      height: `${this.#currentZone.heightPx * scale}px`,
+      borderLeft: "1.5px dashed #2b7cd3",
+      borderTop: "none",
+      display: "block",
+    } satisfies Partial<CSSStyleDeclaration>);
+  }
+
+  #showRowGuide(): void {
+    if (!this.#currentZone || this.#quickRowIndex <= 0) return;
+    const scale = this.#callbacks.scale();
+    const borderY = this.#currentZone.yPx + this.#currentZone.rowEdges[this.#quickRowIndex]!;
+    Object.assign(this.quickGuide.style, {
+      left: `${this.#currentZone.xPx * scale}px`,
+      top: `${borderY * scale}px`,
+      width: `${this.#currentZone.widthPx * scale}px`,
+      height: "1px",
+      borderTop: "1.5px dashed #2b7cd3",
+      borderLeft: "none",
+      display: "block",
+    } satisfies Partial<CSSStyleDeclaration>);
+  }
+
+  /** Show the column drag guideline at a specific page-local X. */
+  showColGuideline(xPx: number, topPx: number, heightPx: number, scale: number): void {
+    Object.assign(this.guideline.style, {
+      left: `${xPx * scale - 1}px`,
+      top: `${topPx * scale}px`,
+      width: "2px",
+      height: `${heightPx * scale}px`,
+      display: "block",
+    } satisfies Partial<CSSStyleDeclaration>);
+  }
+
+  /** Show the row drag guideline at a specific page-local Y. */
+  showRowGuideline(leftPx: number, yPx: number, widthPx: number, scale: number): void {
+    Object.assign(this.guideline.style, {
+      left: `${leftPx * scale}px`,
+      top: `${yPx * scale - 1}px`,
+      width: `${widthPx * scale}px`,
+      height: "2px",
+      display: "block",
+    } satisfies Partial<CSSStyleDeclaration>);
+  }
+
+  /** Hide the drag guideline. */
+  hideGuideline(): void {
+    this.guideline.style.display = "none";
+  }
+
+  /** Show the bounding box guideline for whole-table corner resize. */
+  showBoxGuideline(
+    xPx: number,
+    yPx: number,
+    widthPx: number,
+    heightPx: number,
+    scale: number,
+  ): void {
+    Object.assign(this.guidelineBox.style, {
+      left: `${xPx * scale}px`,
+      top: `${yPx * scale}px`,
+      width: `${widthPx * scale}px`,
+      height: `${heightPx * scale}px`,
+      display: "block",
+    } satisfies Partial<CSSStyleDeclaration>);
+  }
+
+  /** Hide the bounding box guideline. */
+  hideBoxGuideline(): void {
+    this.guidelineBox.style.display = "none";
+  }
+
+  /** Hide all table overlays (e.g. when leaving the table or during a non-table drag). */
+  hideAll(): void {
+    this.hideCorner();
+    this.hideQuickCol();
+    this.hideQuickRow();
+    this.hideGuideline();
+    this.hideBoxGuideline();
+    this.quickGuide.style.display = "none";
+    this.#currentZone = null;
+  }
+
+  destroy(): void {
+    this.hideAll();
+    this.el.remove();
+  }
+}

--- a/packages/editor/src/document/extensions/commands.spec.ts
+++ b/packages/editor/src/document/extensions/commands.spec.ts
@@ -230,6 +230,39 @@ describe("table row / column commands", () => {
     expect(tableAfterCol.child(0).child(1).textContent).toBe("");
   });
 
+  it("insert-row-at and insert-column-at insert at specific indices", () => {
+    const editor = build();
+    editor.commands["insert-table"]();
+    expect(tablesOf(editor)[0]!.childCount).toBe(3);
+
+    // Insert row at index 1
+    caretInCell(editor, 0, 0);
+    expect(editor.commands["insert-row-at"](1)).toBe(true);
+    expect(tablesOf(editor)[0]!.childCount).toBe(4);
+
+    // Insert column at index 2
+    expect(editor.commands["insert-column-at"](2)).toBe(true);
+    const table = tablesOf(editor)[0]!;
+    for (let r = 0; r < table.childCount; r += 1) {
+      expect(table.child(r).childCount).toBe(4);
+    }
+  });
+
+  it("set-table-column-widths and set-table-row-height update attributes", () => {
+    const editor = build();
+    editor.commands["insert-table"]();
+    caretInCell(editor, 0, 0);
+
+    expect(editor.commands["set-table-column-widths"]([1500, 2500, 3000])).toBe(true);
+    expect(tablesOf(editor)[0]!.attrs.columnWidths).toEqual([1500, 2500, 3000]);
+
+    expect(editor.commands["set-table-row-height"](1, { rule: "atLeast", value: 600 })).toBe(true);
+    expect(tablesOf(editor)[0]!.child(1).attrs.height).toEqual({
+      rule: "atLeast",
+      value: 600,
+    });
+  });
+
   it("delete-row removes the caret's row; the last row deletes the table", () => {
     const editor = build();
     editor.commands["insert-table"]();

--- a/packages/editor/src/document/extensions/commands.spec.ts
+++ b/packages/editor/src/document/extensions/commands.spec.ts
@@ -566,6 +566,51 @@ describe("merge / split table commands", () => {
     expect(row.childCount).toBe(1);
     expect(row.child(0).attrs.columnSpan).toBe(3);
   });
+
+  it("merge-cells preserves paragraph content from merged cells", () => {
+    const editor = build();
+    editor.commands["insert-table"]();
+    caretInCell(editor, 0, 0);
+    editor.view.dispatch(editor.state.tr.insertText("Alpha"));
+    caretInCell(editor, 0, 1);
+    editor.view.dispatch(editor.state.tr.insertText("Beta"));
+    selectCells(editor, 0, 0, 0, 1);
+    expect(editor.commands["merge-cells"]()).toBe(true);
+    const masterCell = tablesOf(editor)[0]!.child(0).child(0);
+    expect(masterCell.childCount).toBe(2);
+    expect(masterCell.child(0).textContent).toBe("Alpha");
+    expect(masterCell.child(1).textContent).toBe("Beta");
+  });
+
+  it("merge-cells works on tables with preexisting merged cells", () => {
+    const editor = build();
+    editor.commands["insert-table"]();
+    // Merge cells 0 and 1 in row 0
+    selectCells(editor, 0, 0, 0, 1);
+    expect(editor.commands["merge-cells"]()).toBe(true);
+    // Now merge cells 0 and 1 in row 1
+    selectCells(editor, 1, 0, 1, 1);
+    expect(editor.commands["merge-cells"]()).toBe(true);
+    const table = tablesOf(editor)[0]!;
+    expect(table.child(0).childCount).toBe(2);
+    expect(table.child(1).childCount).toBe(2);
+  });
+
+  it("split-cell unmerges vertical merge and restores all continuation cells", () => {
+    const editor = build();
+    editor.commands["insert-table"]();
+    selectCells(editor, 0, 0, 1, 0);
+    expect(editor.commands["merge-cells"]()).toBe(true);
+    const tableBefore = tablesOf(editor)[0]!;
+    expect(tableBefore.child(1).child(0).attrs.verticalMerge).toBe("continue");
+
+    // Split cell at row 0, col 0
+    caretInCell(editor, 0, 0);
+    expect(editor.commands["split-cell"]()).toBe(true);
+    const tableAfter = tablesOf(editor)[0]!;
+    expect(tableAfter.child(0).child(0).attrs.verticalMerge).toBeFalsy();
+    expect(tableAfter.child(1).child(0).attrs.verticalMerge).toBeFalsy();
+  });
 });
 
 describe("cell size / autofit commands", () => {

--- a/packages/editor/src/document/extensions/commands.ts
+++ b/packages/editor/src/document/extensions/commands.ts
@@ -11,10 +11,10 @@ import type { Node as PMNode, ResolvedPos } from "@tiptap/pm/model";
 import type { Mark } from "@tiptap/pm/model";
 import type { EditorState } from "@tiptap/pm/state";
 import type { Transaction } from "@tiptap/pm/state";
-import { NodeSelection, TextSelection } from "@tiptap/pm/state";
+import { NodeSelection, Selection, TextSelection } from "@tiptap/pm/state";
 import { DocAttrStep } from "@tiptap/pm/transform";
 
-import { CellSelection, cellsInRect } from "../canvas/cell-selection";
+import { CellSelection, cellsInRect, gridColOf, spanOf } from "../canvas/cell-selection";
 
 /**
  * Document editor commands (Office.js-style "add-in commands") as native
@@ -2184,6 +2184,9 @@ export const DocumentCommands = Extension.create({
       // "continue" (their content stays put — the layout folds continue
       // cells into the restart cell, so nothing is lost). Grid math is
       // cellIndex-approximate, so a span-mismatched row is left untouched.
+      // Word's Merge Cells over the selection's bounding rectangle.
+      // Rebuilds merged rows with proper OOXML columnSpan and verticalMerge ("restart" / "continue"),
+      // while preserving all paragraphs and blocks from every merged cell in the master cell.
       "merge-cells":
         () =>
         ({ state, dispatch }) => {
@@ -2200,68 +2203,249 @@ export const DocumentCommands = Extension.create({
           const toA = ancestryAt($to);
           if (!fromA || !toA || fromA.rowAt < 0 || toA.rowAt < 0) return false;
           if ($from.before(fromA.tableAt) !== $to.before(toA.tableAt)) return false;
+
+          const tablePos = $from.before(fromA.tableAt);
           const tableNode = $from.node(fromA.tableAt);
-          const grid = (tableNode.attrs.columnWidths as number[] | null)?.length ?? 0;
-          const c1 = Math.min($from.index(fromA.rowAt), $to.index(toA.rowAt));
-          const c2 = Math.max($from.index(fromA.rowAt), $to.index(toA.rowAt));
-          const rowFrom = Math.min($from.index(fromA.tableAt), $to.index(toA.tableAt));
-          const rowTo = Math.max($from.index(fromA.tableAt), $to.index(toA.tableAt));
+
+          const rA = { row: $from.index(fromA.tableAt), cell: $from.index(fromA.rowAt) };
+          const rH = { row: $to.index(toA.tableAt), cell: $to.index(toA.rowAt) };
+          const rowFrom = Math.min(rA.row, rH.row);
+          const rowTo = Math.max(rA.row, rH.row);
+          const c1 = Math.min(rA.cell, rH.cell);
+          const c2 = Math.max(rA.cell, rH.cell);
           if (rowFrom === rowTo && c1 === c2) return false;
+
+          const anchorRowNode = tableNode.child(rA.row);
+          const headRowNode = tableNode.child(rH.row);
+          const colFrom = Math.min(
+            gridColOf(anchorRowNode, rA.cell),
+            gridColOf(headRowNode, rH.cell),
+          );
+          const colTo = Math.max(
+            gridColOf(anchorRowNode, rA.cell) + spanOf(anchorRowNode.child(rA.cell)!),
+            gridColOf(headRowNode, rH.cell) + spanOf(headRowNode.child(rH.cell)!),
+          );
+
+          const totalCols = colTo - colFrom;
+          const totalRows = rowTo - rowFrom + 1;
+          if (totalCols <= 1 && totalRows <= 1) return false;
+
           if (dispatch) {
-            const tablePos = $from.before(fromA.tableAt);
-            // Row indices into the table's children — the ancestry depths are
-            // not indexes (a depth-2 rowAt would address the last row).
+            // 1. Collect all non-empty block content from all merged cells in row-major order
+            const collectedBlocks: PMNode[] = [];
+            for (let r = rowFrom; r <= rowTo; r += 1) {
+              const rowNode = tableNode.child(r);
+              let cCol = 0;
+              for (let c = 0; c < rowNode.childCount; c += 1) {
+                const cell = rowNode.child(c);
+                const span = spanOf(cell);
+                const cEnd = cCol + span;
+                if (cCol < colTo && cEnd > colFrom) {
+                  cell.forEach((child) => {
+                    if (child.isTextblock && child.content.size === 0) return;
+                    collectedBlocks.push(child);
+                  });
+                }
+                cCol = cEnd;
+              }
+            }
+            if (collectedBlocks.length === 0) {
+              collectedBlocks.push(state.schema.nodes.paragraph.create());
+            }
+
+            // 2. Rebuild rows bottom-up so document positions remain stable
             const tr = state.tr;
             for (let r = rowTo; r >= rowFrom; r -= 1) {
               const rowNode = tableNode.child(r);
-              // Bottom-up keeps positions valid as earlier deletions shift
-              // later ones; a row that doesn't match the grid exactly (a
-              // previously merged one) is skipped rather than corrupted.
-              if (grid > 0 && rowNode.childCount !== grid) continue;
               let rowPos = tablePos + 1;
               for (let i = 0; i < r; i += 1) rowPos += tableNode.child(i).nodeSize;
-              const last = Math.min(c2, rowNode.childCount - 1);
-              if (c1 > last) continue;
-              let basePos = rowPos + 1;
-              for (let c = 0; c < c1; c += 1) basePos += rowNode.child(c).nodeSize;
-              const base = rowNode.child(c1);
-              tr.setNodeMarkup(basePos, undefined, {
-                ...base.attrs,
-                columnSpan: last > c1 ? last - c1 + 1 : null,
-                verticalMerge: r > rowFrom ? "continue" : base.attrs.verticalMerge,
-              });
-              for (let c = last; c > c1; c -= 1) {
-                let cellPos = rowPos + 1;
-                for (let cc = 0; cc < c; cc += 1) cellPos += rowNode.child(cc).nodeSize;
-                tr.delete(cellPos, cellPos + rowNode.child(c).nodeSize);
+
+              const newCells: PMNode[] = [];
+              let cCol = 0;
+              let mergedInserted = false;
+
+              for (let c = 0; c < rowNode.childCount; c += 1) {
+                const cell = rowNode.child(c);
+                const span = spanOf(cell);
+                const cEnd = cCol + span;
+
+                if (cEnd <= colFrom || cCol >= colTo) {
+                  newCells.push(cell);
+                } else {
+                  if (!mergedInserted) {
+                    mergedInserted = true;
+                    if (r === rowFrom) {
+                      const masterAttrs = {
+                        ...cell.attrs,
+                        columnSpan: totalCols > 1 ? totalCols : null,
+                        verticalMerge: null,
+                      };
+                      newCells.push(cell.type.create(masterAttrs, collectedBlocks));
+                    } else {
+                      const contAttrs = {
+                        ...cell.attrs,
+                        columnSpan: totalCols > 1 ? totalCols : null,
+                        verticalMerge: "continue",
+                      };
+                      newCells.push(
+                        cell.type.create(contAttrs, [state.schema.nodes.paragraph.create()]),
+                      );
+                    }
+                  }
+                }
+                cCol = cEnd;
               }
+
+              const newRow = rowNode.type.create(rowNode.attrs, newCells);
+              tr.replaceWith(rowPos, rowPos + rowNode.nodeSize, newRow);
             }
+
+            // 3. Set selection in the master cell
+            let masterPos = tablePos + 1;
+            for (let i = 0; i < rowFrom; i += 1) {
+              masterPos += tr.doc.nodeAt(tablePos)!.child(i).nodeSize;
+            }
+            let cellPos = masterPos + 1;
+            const updatedRow = tr.doc.nodeAt(tablePos)!.child(rowFrom);
+            let curCol = 0;
+            for (let c = 0; c < updatedRow.childCount; c += 1) {
+              const cell = updatedRow.child(c);
+              if (curCol === colFrom) break;
+              curCol += spanOf(cell);
+              cellPos += cell.nodeSize;
+            }
+            const sel = Selection.findFrom(tr.doc.resolve(cellPos + 1), 1, true);
+            if (sel) tr.setSelection(sel);
             dispatch(tr.scrollIntoView());
           }
           return true;
         },
-      // Word's Split Cells without the dialog: a merged cell (columnSpan or
-      // verticalMerge) returns to its own single grid cell, empty twins
-      // taking the spanned columns. The dialog's rows×cols form is not built.
+      // Word's Split Cells: splits horizontally merged (columnSpan > 1) and/or
+      // vertically merged ("restart" / "continue") cells back to individual grid cells.
       "split-cell":
         () =>
         ({ state, dispatch }) => {
           const anchor = tableAncestry(state);
-          if (!anchor || anchor.cellAt < 0) return false;
+          if (!anchor || anchor.cellAt < 0 || anchor.rowAt < 0 || anchor.tableAt < 0) return false;
           const { $from } = state.selection;
+          const tableNode = $from.node(anchor.tableAt);
+          const tablePos = $from.before(anchor.tableAt);
           const cell = $from.node(anchor.cellAt);
-          const span = (cell.attrs.columnSpan as number | null) ?? 1;
-          if (span < 2 && !cell.attrs.verticalMerge) return false;
+          const span = spanOf(cell);
+          const vMerge = cell.attrs.verticalMerge as string | null | undefined;
+
+          const curRowIdx = $from.index(anchor.tableAt);
+          const curCellIdx = $from.index(anchor.rowAt);
+          const targetCol = gridColOf(tableNode.child(curRowIdx), curCellIdx);
+
+          let hasContinueBelow = false;
+          if (curRowIdx + 1 < tableNode.childCount) {
+            const nextRow = tableNode.child(curRowIdx + 1);
+            let cCol = 0;
+            for (let c = 0; c < nextRow.childCount; c += 1) {
+              const cNode = nextRow.child(c);
+              if (cCol === targetCol && cNode.attrs.verticalMerge === "continue") {
+                hasContinueBelow = true;
+                break;
+              }
+              cCol += spanOf(cNode);
+            }
+          }
+
+          const isVerticalMerge = vMerge === "restart" || vMerge === "continue" || hasContinueBelow;
+
+          if (span <= 1 && !isVerticalMerge) return false;
+
           if (dispatch) {
-            const cellPos = $from.before(anchor.cellAt);
-            const tr = state.tr.setNodeMarkup(cellPos, undefined, {
-              ...cell.attrs,
-              columnSpan: null,
-              verticalMerge: null,
-            });
-            const blank = cell.type.create(null, state.schema.nodes.paragraph.create());
-            for (let i = 0; i < span - 1; i += 1) {
-              tr.insert(cellPos + cell.nodeSize, blank);
+            const tr = state.tr;
+
+            if (isVerticalMerge) {
+              let restartRowIdx = curRowIdx;
+              if (vMerge === "continue") {
+                for (let r = curRowIdx - 1; r >= 0; r -= 1) {
+                  const row = tableNode.child(r);
+                  let col = 0;
+                  for (let c = 0; c < row.childCount; c += 1) {
+                    const cNode = row.child(c);
+                    if (col === targetCol) {
+                      if (cNode.attrs.verticalMerge !== "continue") {
+                        restartRowIdx = r;
+                      }
+                      break;
+                    }
+                    col += spanOf(cNode);
+                  }
+                  if (restartRowIdx !== curRowIdx) break;
+                }
+              }
+
+              const affectedRowIndices: number[] = [restartRowIdx];
+              for (let r = restartRowIdx + 1; r < tableNode.childCount; r += 1) {
+                const row = tableNode.child(r);
+                let col = 0;
+                let isContinue = false;
+                for (let c = 0; c < row.childCount; c += 1) {
+                  const cNode = row.child(c);
+                  if (col === targetCol) {
+                    if (cNode.attrs.verticalMerge === "continue") {
+                      isContinue = true;
+                    }
+                    break;
+                  }
+                  col += spanOf(cNode);
+                }
+                if (isContinue) {
+                  affectedRowIndices.push(r);
+                } else {
+                  break;
+                }
+              }
+
+              for (let i = affectedRowIndices.length - 1; i >= 0; i -= 1) {
+                const r = affectedRowIndices[i]!;
+                const rowNode = tableNode.child(r);
+                let rowPos = tablePos + 1;
+                for (let j = 0; j < r; j += 1) rowPos += tableNode.child(j).nodeSize;
+
+                const newCells: PMNode[] = [];
+                let col = 0;
+                for (let c = 0; c < rowNode.childCount; c += 1) {
+                  const cNode = rowNode.child(c);
+                  const cSpan = spanOf(cNode);
+                  if (col === targetCol) {
+                    const unmergedAttrs = {
+                      ...cNode.attrs,
+                      columnSpan: null,
+                      verticalMerge: null,
+                    };
+                    newCells.push(cNode.type.create(unmergedAttrs, cNode.content));
+                    for (let s = 1; s < cSpan; s += 1) {
+                      newCells.push(
+                        cNode.type.create(
+                          { ...cNode.attrs, columnSpan: null, verticalMerge: null },
+                          [state.schema.nodes.paragraph.create()],
+                        ),
+                      );
+                    }
+                  } else {
+                    newCells.push(cNode);
+                  }
+                  col += cSpan;
+                }
+                const newRow = rowNode.type.create(rowNode.attrs, newCells);
+                tr.replaceWith(rowPos, rowPos + rowNode.nodeSize, newRow);
+              }
+            } else if (span > 1) {
+              const cellPos = $from.before(anchor.cellAt);
+              tr.setNodeMarkup(cellPos, undefined, {
+                ...cell.attrs,
+                columnSpan: null,
+                verticalMerge: null,
+              });
+              const blank = cell.type.create(null, [state.schema.nodes.paragraph.create()]);
+              for (let i = 0; i < span - 1; i += 1) {
+                tr.insert(cellPos + cell.nodeSize, blank);
+              }
             }
             dispatch(tr.scrollIntoView());
           }

--- a/packages/editor/src/document/extensions/commands.ts
+++ b/packages/editor/src/document/extensions/commands.ts
@@ -88,8 +88,16 @@ declare module "@tiptap/core" {
       // Table context commands (the Table Design / Layout contextual tabs).
       "insert-row-above": () => ReturnType;
       "insert-row-below": () => ReturnType;
+      "insert-row-at": (index: number, tablePos?: number) => ReturnType;
       "insert-column-left": () => ReturnType;
       "insert-column-right": () => ReturnType;
+      "insert-column-at": (index: number, tablePos?: number) => ReturnType;
+      "set-table-column-widths": (widths: number[], tablePos?: number) => ReturnType;
+      "set-table-row-height": (
+        rowIndex: number,
+        height: { rule: "atLeast" | "exact"; value: number } | null,
+        tablePos?: number,
+      ) => ReturnType;
       "delete-row": () => ReturnType;
       "delete-column": () => ReturnType;
       "select-table": () => ReturnType;
@@ -186,8 +194,12 @@ export const WIRED_DISPATCH: ReadonlySet<string> = new Set([
   "delete-table",
   "insert-row-above",
   "insert-row-below",
+  "insert-row-at",
   "insert-column-left",
   "insert-column-right",
+  "insert-column-at",
+  "set-table-column-widths",
+  "set-table-row-height",
   "delete-row",
   "delete-column",
   "select-table",
@@ -714,7 +726,7 @@ export function tableAncestry(state: EditorState): {
 
 /** {@link tableAncestry} for an arbitrary position — Merge Cells resolves the
  *  selection's two ends independently. */
-function ancestryAt($pos: ResolvedPos): {
+export function ancestryAt($pos: ResolvedPos): {
   tableAt: number;
   rowAt: number;
   cellAt: number;
@@ -1603,6 +1615,41 @@ export const DocumentCommands = Extension.create({
           }
           return true;
         },
+      // Insert an empty row at a specific row index (0..nRows).
+      "insert-row-at":
+        (rowIndex: number, targetTablePos?: number) =>
+        ({ state, dispatch }) => {
+          let tablePos = targetTablePos;
+          let tableNode: PMNode | null = null;
+          if (tablePos != null) {
+            tableNode = state.doc.nodeAt(tablePos);
+          } else {
+            const anchor = tableAncestry(state);
+            if (!anchor) return false;
+            tablePos = state.selection.$from.before(anchor.tableAt);
+            tableNode = state.selection.$from.node(anchor.tableAt);
+          }
+          if (!tableNode || tablePos == null || tableNode.childCount === 0) return false;
+          if (dispatch) {
+            const tr = state.tr;
+            const templateIdx = Math.min(rowIndex > 0 ? rowIndex - 1 : 0, tableNode.childCount - 1);
+            const templateRow = tableNode.child(templateIdx);
+            const emptyCells: PMNode[] = [];
+            templateRow.forEach((cell) => {
+              const para = state.schema.nodes.paragraph.create();
+              emptyCells.push(cell.type.createAndFill(cell.attrs, [para])!);
+            });
+            const newRow = templateRow.type.create(templateRow.attrs, emptyCells);
+            let insertPos = tablePos + 1;
+            for (let r = 0; r < Math.min(rowIndex, tableNode.childCount); r += 1) {
+              insertPos += tableNode.child(r).nodeSize;
+            }
+            tr.insert(insertPos, newRow);
+            tr.setSelection(TextSelection.near(tr.doc.resolve(insertPos + 2)));
+            dispatch(tr.scrollIntoView());
+          }
+          return true;
+        },
       // One empty cell per row, copied from each row's cell attrs at the current column
       // index. Bottom-up keeps positions valid as earlier edits shift later ones.
       "insert-column-right":
@@ -1631,6 +1678,12 @@ export const DocumentCommands = Extension.create({
               if (r === $from.index(anchor.rowAt)) {
                 targetCellPos = cellPos;
               }
+            }
+            if (Array.isArray(tableNode.attrs.columnWidths)) {
+              const widths = [...(tableNode.attrs.columnWidths as number[])];
+              const w = widths[cellIndex] ?? 2880;
+              widths.splice(cellIndex + 1, 0, w);
+              tr.setNodeMarkup(tablePos, undefined, { ...tableNode.attrs, columnWidths: widths });
             }
             if (targetCellPos > 0) {
               tr.setSelection(TextSelection.near(tr.doc.resolve(targetCellPos + 1)));
@@ -1666,10 +1719,122 @@ export const DocumentCommands = Extension.create({
                 targetCellPos = cellPos;
               }
             }
+            if (Array.isArray(tableNode.attrs.columnWidths)) {
+              const widths = [...(tableNode.attrs.columnWidths as number[])];
+              const w = widths[cellIndex] ?? 2880;
+              widths.splice(cellIndex, 0, w);
+              tr.setNodeMarkup(tablePos, undefined, { ...tableNode.attrs, columnWidths: widths });
+            }
             if (targetCellPos > 0) {
               tr.setSelection(TextSelection.near(tr.doc.resolve(targetCellPos + 1)));
             }
             dispatch(tr.scrollIntoView());
+          }
+          return true;
+        },
+      // Insert a column at a specific column index (0..nCols).
+      "insert-column-at":
+        (colIndex: number, targetTablePos?: number) =>
+        ({ state, dispatch }) => {
+          let tablePos = targetTablePos;
+          let tableNode: PMNode | null = null;
+          if (tablePos != null) {
+            tableNode = state.doc.nodeAt(tablePos);
+          } else {
+            const anchor = tableAncestry(state);
+            if (!anchor) return false;
+            tablePos = state.selection.$from.before(anchor.tableAt);
+            tableNode = state.selection.$from.node(anchor.tableAt);
+          }
+          if (!tableNode || tablePos == null || tableNode.childCount === 0) return false;
+          if (dispatch) {
+            const tr = state.tr;
+            let targetCellPos = -1;
+            for (let r = tableNode.childCount - 1; r >= 0; r -= 1) {
+              const rowNode = tableNode.child(r);
+              let rowPos = tablePos + 1;
+              for (let i = 0; i < r; i += 1) rowPos += tableNode.child(i).nodeSize;
+              const idx = Math.min(colIndex, rowNode.childCount);
+              let cellPos = rowPos + 1;
+              for (let c = 0; c < idx; c += 1) cellPos += rowNode.child(c).nodeSize;
+              const templateIdx = Math.min(colIndex > 0 ? colIndex - 1 : 0, rowNode.childCount - 1);
+              const template = rowNode.child(templateIdx);
+              const para = state.schema.nodes.paragraph.create();
+              const emptyCell = template.type.createAndFill(template.attrs, [para])!;
+              tr.insert(cellPos, emptyCell);
+              if (r === 0) targetCellPos = cellPos;
+            }
+            if (Array.isArray(tableNode.attrs.columnWidths)) {
+              const widths = [...(tableNode.attrs.columnWidths as number[])];
+              const w = widths[colIndex - 1] ?? widths[colIndex] ?? 2880;
+              widths.splice(colIndex, 0, w);
+              tr.setNodeMarkup(tablePos, undefined, { ...tableNode.attrs, columnWidths: widths });
+            }
+            if (targetCellPos > 0) {
+              tr.setSelection(TextSelection.near(tr.doc.resolve(targetCellPos + 1)));
+            }
+            dispatch(tr.scrollIntoView());
+          }
+          return true;
+        },
+      // Set table column widths directly on the table node.
+      "set-table-column-widths":
+        (widths: number[], targetTablePos?: number) =>
+        ({ state, dispatch }) => {
+          let tablePos = targetTablePos;
+          let tableNode: PMNode | null = null;
+          if (tablePos != null) {
+            tableNode = state.doc.nodeAt(tablePos);
+          } else {
+            const anchor = tableAncestry(state);
+            if (!anchor) return false;
+            tablePos = state.selection.$from.before(anchor.tableAt);
+            tableNode = state.selection.$from.node(anchor.tableAt);
+          }
+          if (!tableNode || tablePos == null) return false;
+          if (dispatch) {
+            dispatch(
+              state.tr
+                .setNodeMarkup(tablePos, undefined, {
+                  ...tableNode.attrs,
+                  columnWidths: widths,
+                })
+                .scrollIntoView(),
+            );
+          }
+          return true;
+        },
+      // Set height on a specific table row.
+      "set-table-row-height":
+        (
+          rowIndex: number,
+          height: { rule: "atLeast" | "exact"; value: number } | null,
+          targetTablePos?: number,
+        ) =>
+        ({ state, dispatch }) => {
+          let tablePos = targetTablePos;
+          let tableNode: PMNode | null = null;
+          if (tablePos != null) {
+            tableNode = state.doc.nodeAt(tablePos);
+          } else {
+            const anchor = tableAncestry(state);
+            if (!anchor) return false;
+            tablePos = state.selection.$from.before(anchor.tableAt);
+            tableNode = state.selection.$from.node(anchor.tableAt);
+          }
+          if (!tableNode || tablePos == null || rowIndex >= tableNode.childCount) return false;
+          if (dispatch) {
+            let rowPos = tablePos + 1;
+            for (let r = 0; r < rowIndex; r += 1) rowPos += tableNode.child(r).nodeSize;
+            const rowNode = state.doc.nodeAt(rowPos)!;
+            dispatch(
+              state.tr
+                .setNodeMarkup(rowPos, undefined, {
+                  ...rowNode.attrs,
+                  height,
+                })
+                .scrollIntoView(),
+            );
           }
           return true;
         },
@@ -1719,6 +1884,13 @@ export const DocumentCommands = Extension.create({
               let cellPos = rowPos + 1;
               for (let c = 0; c < idx; c += 1) cellPos += rowNode.child(c).nodeSize;
               tr.delete(cellPos, cellPos + rowNode.child(idx).nodeSize);
+            }
+            if (Array.isArray(tableNode.attrs.columnWidths)) {
+              const widths = [...(tableNode.attrs.columnWidths as number[])];
+              if (cellIndex < widths.length) {
+                widths.splice(cellIndex, 1);
+                tr.setNodeMarkup(tablePos, undefined, { ...tableNode.attrs, columnWidths: widths });
+              }
             }
             dispatch(tr.scrollIntoView());
           }


### PR DESCRIPTION
## Summary

This PR enhances table cell merge and split capabilities following Microsoft Word and OOXML specifications:

1. **Robust Content-Preserving Cell Merge**:
   - Merging cells now collects and preserves all paragraphs and block content from every cell within the merge rectangle into the master cell, rather than discarding content.
   - Sets OOXML-compliant `columnSpan` and `verticalMerge` (`continue` on continuation rows) attributes.
   - Operates cleanly on tables with preexisting merged cells by calculating actual grid columns via `gridColOf`.

2. **Full Multi-Row Vertical and Horizontal Cell Split**:
   - Splitting horizontally merged cells restores individual 1x1 cells across columns with empty paragraphs in twin cells.
   - Splitting vertically merged cells accurately detects all continuation cells below and unmerges the entire vertical merge span back into independent rows.
   - Operates safely on both `CellSelection` from canvas drag and caret-based text selections.

## Testing

- Added unit tests in `packages/editor/src/document/extensions/commands.spec.ts`:
  - `merge-cells preserves paragraph content from merged cells`
  - `merge-cells works on tables with preexisting merged cells`
  - `split-cell unmerges vertical merge and restores all continuation cells`
- All 38 test files and 622 tests passing monorepo-wide (`pnpm test`).
- Formatting and type checking 100% clean with zero warnings (`pnpm check`).